### PR TITLE
Add Android build workflow

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,34 @@
+name: Android Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+    - name: Set up Android SDK
+      uses: android-actions/setup-android@v3
+    - name: Delete previous artifact
+      uses: geekyeggo/delete-artifact@v2
+      with:
+        name: android-debug-apk
+      continue-on-error: true
+    - name: Build debug APK
+      run: ./gradlew clean :android:assembleDebug
+    - name: Upload APK artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: android-debug-apk
+        path: android/build/outputs/apk/debug/*.apk


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Android debug APK
- clean previous build artifacts before uploading the new APK

## Testing
- `./gradlew clean :android:assembleDebug` *(fails: SDK location not found)*
- `./gradlew :core:test`


------
https://chatgpt.com/codex/tasks/task_e_689207277d00832aa8f52d44f5af981c