### PR TITLE
Add tools module with asset preview example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ gradle-app.setting
 /headless/build/
 /server/build/
 /shared/build/
+/tools/build/
 
 ## Java:
 *.class

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 // A list of which subprojects to load as part of the same larger project.
 // You can remove Strings from the list and reload the Gradle project
 // if you want to temporarily disable a subproject.
-include 'lwjgl3', 'core', 'android', 'ios', 'html'
+include 'lwjgl3', 'core', 'android', 'ios', 'html', 'tools'

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -1,0 +1,20 @@
+apply plugin: 'application'
+
+sourceSets.main.resources.srcDirs += [ rootProject.file('assets').path ]
+
+mainClassName = 'tatar.eljah.hamsters.tools.ToolsLauncher'
+application.setMainClass(mainClassName)
+
+eclipse.project.name = appName + '-tools'
+
+java.sourceCompatibility = 8
+java.targetCompatibility = 8
+if (JavaVersion.current().isJava9Compatible()) {
+    compileJava.options.release.set(8)
+}
+
+dependencies {
+    implementation "com.badlogicgames.gdx:gdx:$gdxVersion"
+    implementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
+    implementation "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
+}

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/ToolsLauncher.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/ToolsLauncher.java
@@ -1,0 +1,59 @@
+package tatar.eljah.hamsters.tools;
+
+import com.badlogic.gdx.ApplicationAdapter;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.utils.ScreenUtils;
+
+public class ToolsLauncher {
+    public static void main(String[] args) {
+        Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+        config.setTitle("Assets Preview");
+        config.setWindowedMode(800, 600);
+        new Lwjgl3Application(new AssetViewer(), config);
+    }
+
+    private static class AssetViewer extends ApplicationAdapter {
+        private SpriteBatch batch;
+        private Texture[] textures;
+        private final String[] files = {
+                "block.png",
+                "controls.png",
+                "grade.png",
+                "hamster.png",
+                "libgdx.png",
+                "liner.png"
+        };
+
+        @Override
+        public void create() {
+            batch = new SpriteBatch();
+            textures = new Texture[files.length];
+            for (int i = 0; i < files.length; i++) {
+                textures[i] = new Texture(files[i]);
+            }
+        }
+
+        @Override
+        public void render() {
+            ScreenUtils.clear(0f, 0f, 0f, 1f);
+            batch.begin();
+            for (int i = 0; i < textures.length; i++) {
+                int x = (i % 3) * 200 + 20;
+                int y = 400 - (i / 3) * 200;
+                batch.draw(textures[i], x, y, 128, 128);
+            }
+            batch.end();
+        }
+
+        @Override
+        public void dispose() {
+            for (Texture t : textures) {
+                t.dispose();
+            }
+            batch.dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `tools` module
- include asset preview launcher that shows existing PNGs
- register `tools` module in settings and ignore its build output

## Testing
- `./gradlew :core:test --rerun-tasks`
- `./gradlew :tools:build`


------
https://chatgpt.com/codex/tasks/task_e_68a450c9f32c832a998ffe940e0765ef