### PR TITLE
Add tools module for asset vectorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,13 @@ Useful Gradle tasks and flags:
 
 Note that most tasks that are not specific to a single project can be run with `name:` prefix, where the `name` should be replaced with the ID of a specific project.
 For example, `core:clean` removes `build` folder only from the `core` project.
+
+## Tools
+
+The `tools` module provides helper utilities. To convert all PNG files in `assets/` into pen-style SVGs, run:
+
+```bash
+./gradlew :tools:run --args blue
+```
+
+Replace `blue` with `red` to use a red pen. The converted files are written to `build/vectorized` alongside generated SVGs.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 // A list of which subprojects to load as part of the same larger project.
 // You can remove Strings from the list and reload the Gradle project
 // if you want to temporarily disable a subproject.
-include 'lwjgl3', 'core', 'android', 'ios', 'html'
+include 'lwjgl3', 'core', 'android', 'ios', 'html', 'tools'

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'application'
+}
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+application {
+    mainClass = 'tools.VectorizeAssets'
+}
+
+tasks.named('run') {
+    workingDir = rootProject.projectDir
+}

--- a/tools/src/main/java/tools/PenVectorize.java
+++ b/tools/src/main/java/tools/PenVectorize.java
@@ -1,3 +1,5 @@
+package tools;
+
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;

--- a/tools/src/main/java/tools/VectorizeAssets.java
+++ b/tools/src/main/java/tools/VectorizeAssets.java
@@ -1,0 +1,32 @@
+package tools;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.stream.Stream;
+
+/**
+ * Example entry point that vectorizes every PNG found in the assets directory
+ * into pen-style PNG and SVG images. Outputs are written to build/vectorized.
+ */
+public class VectorizeAssets {
+    public static void main(String[] args) throws IOException {
+        String color = args.length > 0 ? args[0] : "blue";
+        Path assetsDir = Paths.get("assets");
+        Path outDir = Paths.get("build", "vectorized");
+        Files.createDirectories(outDir);
+        try (Stream<Path> files = Files.walk(assetsDir)) {
+            files.filter(p -> p.toString().toLowerCase().endsWith(".png"))
+                 .forEach(p -> {
+                     try {
+                         Path target = outDir.resolve(p.getFileName());
+                         Files.copy(p, target, StandardCopyOption.REPLACE_EXISTING);
+                         PenVectorize.main(new String[]{target.toString(), "--color", color});
+                         System.out.println("Vectorized " + p + " -> " + target.resolveSibling(
+                                 target.getFileName().toString().replaceFirst("\\.png$", ".svg")));
+                     } catch (IOException e) {
+                         throw new RuntimeException(e);
+                     }
+                 });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `tools` Gradle module with Java 17 setup
- move `PenVectorize` into module and add `VectorizeAssets` example to convert PNGs to pen-style SVGs
- document how to run vectorization from `README`

## Testing
- `./gradlew :tools:build`
- `./gradlew :tools:run --args blue`


------
https://chatgpt.com/codex/tasks/task_e_68a458b15d78832a9103cf156b242d36