### PR TITLE
Use smaller hamster SVG for faster headless launch

### DIFF
--- a/core/src/main/java/tatar/eljah/hamsters/Main.java
+++ b/core/src/main/java/tatar/eljah/hamsters/Main.java
@@ -44,15 +44,18 @@ public class Main extends ApplicationAdapter {
     public void create() {
         batch = new SpriteBatch();
 
-        Pixmap hamsterPixmap = Svg2Pixmap.svg2Pixmap(Gdx.files.internal("hamster.svg").readString());
+        Pixmap hamsterPixmap = Svg2Pixmap.svg2Pixmap(
+                Gdx.files.internal("hamster_old.svg").readString(), 64, 64);
         hamsterTexture = new Texture(hamsterPixmap);
         hamsterPixmap.dispose();
 
-        Pixmap gradePixmap = Svg2Pixmap.svg2Pixmap(Gdx.files.internal("grade.svg").readString());
+        Pixmap gradePixmap = Svg2Pixmap.svg2Pixmap(
+                Gdx.files.internal("grade.svg").readString(), 64, 64);
         gradeTexture = new Texture(gradePixmap);
         gradePixmap.dispose();
 
-        Pixmap blockPixmap = Svg2Pixmap.svg2Pixmap(Gdx.files.internal("block.svg").readString());
+        Pixmap blockPixmap = Svg2Pixmap.svg2Pixmap(
+                Gdx.files.internal("block.svg").readString(), 64, 64);
         blockTexture = new Texture(blockPixmap);
         blockPixmap.dispose();
 


### PR DESCRIPTION
## Summary
- use compact `hamster_old.svg` scaled to 64x64 to avoid lengthy SVG conversion
- scale grade and block SVG assets to 64x64 as well

## Testing
- `xvfb-run -s '-screen 0 1024x768x24' ./gradlew :lwjgl3:run -Pheadless=true`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57abc9c40832aac2b7d7c021a5b1a