### PR TITLE
Handle missing SVG colors to prevent loading hang

### DIFF
--- a/core/src/main/java/io/github/fxzjshm/gdx/svg2pixmap/H.java
+++ b/core/src/main/java/io/github/fxzjshm/gdx/svg2pixmap/H.java
@@ -434,9 +434,12 @@ public class H {
                 return Color.CLEAR;
             }
             if (color.startsWith("#")) return Color.valueOf(color.replace("#", ""));
-            return colorMap.get(color);
-        } catch (NullPointerException | GdxRuntimeException ignored) {
+            Color named = colorMap.get(color);
+            if (named != null) return named;
             return defaultColor;
+        } catch (NullPointerException | GdxRuntimeException ignored) {
+            // missing attribute should mean "no color" instead of defaulting to black
+            return Color.CLEAR;
         }
     }
 
@@ -482,11 +485,15 @@ public class H {
             }
             fill = H.svgReadColor(element, "fill");
             stroke = H.svgReadColor(element, "stroke");
-            try {
-                strokeWidth = H.svgReadDouble(H.getAttribute(element, "stroke-width"), Math.sqrt(width * width + height * height));
-            } catch (GdxRuntimeException | NullPointerException | NumberFormatException ignored) {
-                // fall back to a visible default so paths without explicit stroke-width remain noticeable
-                strokeWidth = Math.max(width, height) / 32.0;
+            if (stroke == null || stroke.equals(Color.CLEAR)) {
+                strokeWidth = 0.0;
+            } else {
+                try {
+                    strokeWidth = H.svgReadDouble(H.getAttribute(element, "stroke-width"), Math.sqrt(width * width + height * height));
+                } catch (GdxRuntimeException | NullPointerException | NumberFormatException ignored) {
+                    // fall back to a visible default so paths without explicit stroke-width remain noticeable
+                    strokeWidth = Math.max(width, height) / 32.0;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- treat absent or unsupported SVG colors as transparent instead of black
- skip default stroke width when stroke color is transparent

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a77bf6f7e4832a8eaed27fa051ae4b