### PR TITLE
Handle tiny sprites without supersampling

### DIFF
--- a/core/src/main/java/io/github/fxzjshm/gdx/svg2pixmap/Svg2Pixmap.java
+++ b/core/src/main/java/io/github/fxzjshm/gdx/svg2pixmap/Svg2Pixmap.java
@@ -364,6 +364,10 @@ public class Svg2Pixmap {
     public static Pixmap svg2Pixmap(String fileContent, int width, int height) {
         checkGWT();
 
+        // Avoid dimming tiny sprites by bypassing supersampling for 1x1 textures
+        if (width == 1 && height == 1) {
+            return svg2PixmapDirectDraw(fileContent, width, height);
+        }
         if (generateScale == 1) return svg2PixmapDirectDraw(fileContent, width, height);
 
         final int scaledWidth = width * generateScale, scaledHeight = height * generateScale,


### PR DESCRIPTION
## Summary
- Restore SVG supersampling factor to 2
- Skip supersampling for 1x1 textures to keep tiny sprites fully opaque

## Testing
- `xvfb-run -s "-screen 0 800x600x24" bash -lc "timeout 60s ./gradlew :lwjgl3:run"` *(screenshot captured but only black pixels)*
- `./gradlew :core:test` *(hangs after :core:test)*

------
https://chatgpt.com/codex/tasks/task_e_68a783ffb600832aa6f91928bf65636a