### PR TITLE
Render hamster from adaptive SVG lines

### DIFF
--- a/assets/hamster4.svg
+++ b/assets/hamster4.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="none" stroke="#0000ff" stroke-width="1"/>
+  <circle cx="24" cy="24" r="4" fill="#0000ff"/>
+  <circle cx="40" cy="24" r="4" fill="#0000ff"/>
+  <path d="M20 40 Q32 50 44 40" stroke="#0000ff" stroke-width="1" fill="none"/>
+</svg>

--- a/core/src/main/java/tatar/eljah/hamsters/Main.java
+++ b/core/src/main/java/tatar/eljah/hamsters/Main.java
@@ -62,8 +62,11 @@ public class Main extends ApplicationAdapter {
         loadingProgress = 0f;
 
         new Thread(() -> {
-            Pixmap hamsterPixmap = Svg2Pixmap.svg2Pixmap(
-                    Gdx.files.internal("hamster.svg").readString(), 64, 64);
+            String hamsterSvg = Gdx.files.internal("hamster4.svg").readString();
+            float strokeScale = Math.max(1f, Gdx.graphics.getWidth() / 800f);
+            hamsterSvg = hamsterSvg.replaceAll("stroke-width=\"[0-9.]+\"",
+                    "stroke-width=\"" + strokeScale + "\"");
+            Pixmap hamsterPixmap = Svg2Pixmap.svg2Pixmap(hamsterSvg, 64, 64);
             loadingProgress = 1f / 3f;
             Gdx.app.postRunnable(() -> {
                 hamsterTexture = new Texture(hamsterPixmap);


### PR DESCRIPTION
## Summary
- add `hamster4.svg` asset
- render hamster using new SVG with screen-scaled stroke width

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew core:test --rerun-tasks` *(hangs running RenderTest)*
- `./gradlew lwjgl3:run` *(fails: GLFW platform unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b97c4febcc832a82e12c4e4bc369a0