### PR TITLE
Improve hamster texture quality

### DIFF
--- a/core/src/main/java/tatar/eljah/hamsters/Main.java
+++ b/core/src/main/java/tatar/eljah/hamsters/Main.java
@@ -63,13 +63,15 @@ public class Main extends ApplicationAdapter {
 
         new Thread(() -> {
             String hamsterSvg = Gdx.files.internal("hamster4.svg").readString();
-            float strokeScale = Math.max(2f, Gdx.graphics.getWidth() / 400f);
+            float finalStroke = Math.max(1.5f, Gdx.graphics.getWidth() / 400f);
+            float strokeScale = finalStroke * (1024f / 80f);
             hamsterSvg = hamsterSvg.replaceAll("stroke-width=\"[0-9.]+\"",
                     "stroke-width=\"" + strokeScale + "\"");
-            Pixmap hamsterPixmap = Svg2Pixmap.svg2Pixmap(hamsterSvg, 64, 64);
+            Pixmap hamsterPixmap = Svg2Pixmap.svg2Pixmap(hamsterSvg, 256, 256);
             loadingProgress = 1f / 3f;
             Gdx.app.postRunnable(() -> {
                 hamsterTexture = new Texture(hamsterPixmap);
+                hamsterTexture.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
                 hamsterPixmap.dispose();
             });
 


### PR DESCRIPTION
## Summary
- Increase hamster SVG conversion resolution and apply linear filtering for smoother rendering.

## Testing
- `XDG_RUNTIME_DIR=/tmp xvfb-run -a -s "-screen 0 800x600x24" bash -lc './gradlew :lwjgl3:run >/tmp/run.log 2>&1 & pid=$!; sleep 60; xwd -silent -root -out /tmp/screen_after.xwd; kill $pid; wait $pid'`
- `./gradlew --no-daemon --console=plain core:test > /tmp/test.log 2>&1; tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b984f661a4832a864a95f0de19a362