### PR TITLE
Apply ballpoint pen effect to hamster SVG rendering

### DIFF
--- a/core/src/main/java/tatar/eljah/hamsters/BallpointEffect.java
+++ b/core/src/main/java/tatar/eljah/hamsters/BallpointEffect.java
@@ -1,0 +1,77 @@
+package tatar.eljah.hamsters;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
+
+/** Utility to apply a ballpoint pen style effect to pixmaps. */
+public class BallpointEffect {
+    private BallpointEffect() {}
+
+    /**
+     * Darkens stroke edges while lightening their centers to mimic a ballpoint pen.
+     * The pixmap is modified in place.
+     */
+    public static void apply(Pixmap pixmap) {
+        int width = pixmap.getWidth();
+        int height = pixmap.getHeight();
+        int[][] dist = new int[width][height];
+        java.util.ArrayDeque<int[]> queue = new java.util.ArrayDeque<>();
+        Color color = new Color();
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                Color.rgba8888ToColor(color, pixmap.getPixel(x, y));
+                if (color.a == 0f) {
+                    dist[x][y] = 0;
+                    queue.add(new int[]{x, y});
+                } else {
+                    dist[x][y] = Integer.MAX_VALUE;
+                }
+            }
+        }
+
+        int[] dx = {-1, 1, 0, 0, -1, -1, 1, 1};
+        int[] dy = {0, 0, -1, 1, -1, 1, -1, 1};
+
+        while (!queue.isEmpty()) {
+            int[] p = queue.poll();
+            int x = p[0];
+            int y = p[1];
+            int d = dist[x][y];
+            for (int i = 0; i < 8; i++) {
+                int nx = x + dx[i];
+                int ny = y + dy[i];
+                if (nx >= 0 && nx < width && ny >= 0 && ny < height && dist[nx][ny] > d + 1) {
+                    dist[nx][ny] = d + 1;
+                    queue.add(new int[]{nx, ny});
+                }
+            }
+        }
+
+        int maxDist = 0;
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                Color.rgba8888ToColor(color, pixmap.getPixel(x, y));
+                if (color.a > 0f && dist[x][y] > maxDist) {
+                    maxDist = dist[x][y];
+                }
+            }
+        }
+
+        Pixmap.Blending old = pixmap.getBlending();
+        pixmap.setBlending(Pixmap.Blending.None);
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                int pixel = pixmap.getPixel(x, y);
+                Color.rgba8888ToColor(color, pixel);
+                if (color.a > 0f) {
+                    float factor = 1f - (float) dist[x][y] / (float) maxDist;
+                    factor = 0.2f + 0.8f * factor;
+                    color.a *= factor;
+                    pixmap.drawPixel(x, y, Color.rgba8888(color));
+                }
+            }
+        }
+        pixmap.setBlending(old);
+    }
+}

--- a/core/src/main/java/tatar/eljah/hamsters/Main.java
+++ b/core/src/main/java/tatar/eljah/hamsters/Main.java
@@ -68,6 +68,7 @@ public class Main extends ApplicationAdapter {
             hamsterSvg = hamsterSvg.replaceAll("stroke-width=\"[0-9.]+\"",
                     "stroke-width=\"" + strokeScale + "\"");
             Pixmap hamsterPixmap = Svg2Pixmap.svg2Pixmap(hamsterSvg, 256, 256);
+            BallpointEffect.apply(hamsterPixmap);
             loadingProgress = 1f / 3f;
             Gdx.app.postRunnable(() -> {
                 hamsterTexture = new Texture(hamsterPixmap);
@@ -177,7 +178,6 @@ public class Main extends ApplicationAdapter {
         }
         return false;
     }
-
 
     @Override
     public void render() {

--- a/core/src/test/java/tatar/eljah/hamsters/BallpointEffectTest.java
+++ b/core/src/test/java/tatar/eljah/hamsters/BallpointEffectTest.java
@@ -1,0 +1,33 @@
+package tatar.eljah.hamsters;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.utils.GdxNativesLoader;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BallpointEffectTest {
+    @Test
+    public void edgePixelsAreMoreOpaqueThanCenter() {
+        GdxNativesLoader.load();
+        Pixmap pixmap = new Pixmap(7, 7, Pixmap.Format.RGBA8888);
+        // transparent background
+        pixmap.setColor(0, 0, 0, 0);
+        pixmap.fill();
+        // draw a filled square
+        pixmap.setColor(0, 0, 0, 1);
+        pixmap.fillRectangle(2, 2, 3, 3);
+
+        BallpointEffect.apply(pixmap);
+
+        Color color = new Color();
+        Color.rgba8888ToColor(color, pixmap.getPixel(2, 2));
+        float edgeAlpha = color.a;
+        Color.rgba8888ToColor(color, pixmap.getPixel(3, 3));
+        float centerAlpha = color.a;
+        pixmap.dispose();
+
+        assertTrue("Edge should be less transparent than center", edgeAlpha > centerAlpha);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `BallpointEffect` utility and disable Pixmap blending for proper stroke gradients
- Invoke ballpoint effect during hamster SVG conversion
- Add headless test verifying stroke edges remain less transparent than centers

## Testing
- `xvfb-run -a ./gradlew :core:test --tests tatar.eljah.hamsters.BallpointEffectTest --no-daemon`
- `xvfb-run -a ./gradlew :core:compileJava`
- `xvfb-run -a ./gradlew :core:test --no-daemon` *(hangs on RenderTest)*

------
https://chatgpt.com/codex/tasks/task_e_68b99b920b00832ab4858309c9147273