### PR TITLE
Improve SVG stroke opacity for vivid rendering

### DIFF
--- a/core/src/main/java/tatar/eljah/hamsters/Main.java
+++ b/core/src/main/java/tatar/eljah/hamsters/Main.java
@@ -237,7 +237,8 @@ public class Main extends ApplicationAdapter {
                         factor = 1f;
                     } else {
                         factor = ((float) dist[x][y] - 1f) / ((float) maxDist - 1f);
-                        factor = 0.2f + 0.8f * factor;
+                        // Increase base opacity so SVG strokes look brighter on screen
+                        factor = 0.5f + 0.5f * factor;
                     }
                     color.a *= factor;
                     pixmap.drawPixel(x, y, Color.rgba8888(color));


### PR DESCRIPTION
## Summary
- increase baseline alpha in `applyBallpointEffect` so SVG strokes appear more vibrant

## Testing
- `./gradlew core:test lwjgl3:test`

------
https://chatgpt.com/codex/tasks/task_e_68b9f2055c0c832a9becb40f3dbe745b