### PR TITLE
Align blocks with notebook lines and refine grade SVG

### DIFF
--- a/assets/grade.svg
+++ b/assets/grade.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" shape-rendering="geometricPrecision">
-  <path d="M 16 20 Q 32 0 48 16 Q 48 28 24 40 Q 16 48 16 56 L 48 56" fill="none" stroke="#cc0000" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="45" viewBox="0 0 32 45" shape-rendering="geometricPrecision">
+  <path d="M6 6 C8 1 18 1 24 5 C28 8 28 12 24 15 C18 20 10 23 10 31 C10 39 6 45 6 45 L30 45" fill="none" stroke="#ff0000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
## Summary
- Trace grade.svg from hand-written reference for a smoother red "2"
- Parse thin line pairs from liner.svg and place blocks so they span between those lines
- Render blocks at full gap height between the notebook lines

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `xvfb-run -a ./gradlew :lwjgl3:run -Dheadless=true`


------
https://chatgpt.com/codex/tasks/task_e_68bb5ef5549c832ab7b9cfb8ff6dccdc