### PR TITLE
Fix block placement between notebook lines

### DIFF
--- a/core/src/main/java/tatar/eljah/hamsters/Main.java
+++ b/core/src/main/java/tatar/eljah/hamsters/Main.java
@@ -193,48 +193,31 @@ public class Main extends ApplicationAdapter {
     }
 
     private float[][] parseBlockRanges(String svg) {
-        java.util.ArrayList<float[]> pairs = new java.util.ArrayList<>();
+        java.util.ArrayList<Float> ys = new java.util.ArrayList<>();
         try (java.io.BufferedReader br = new java.io.BufferedReader(new java.io.StringReader(svg))) {
             String line;
-            float currentTop = Float.NaN;
-            int state = 0; // 0 = expect top thin, 1 = expect baseline, 2 = expect bottom thin
             while ((line = br.readLine()) != null) {
-                if (!line.contains("H800") || !line.contains("stroke-width")) continue;
-                int m = line.indexOf("M0 ");
-                int h = line.indexOf("H800", m);
-                int sw = line.indexOf("stroke-width=\"");
-                if (m < 0 || h < 0 || sw < 0) continue;
-                int swEnd = line.indexOf("\"", sw + 14);
-                if (swEnd < 0) continue;
-                float y;
-                float width;
-                try {
-                    y = Float.parseFloat(line.substring(m + 3, h));
-                    width = Float.parseFloat(line.substring(sw + 14, swEnd));
-                } catch (NumberFormatException e) {
-                    continue;
-                }
-
-                if (width == 2f) {
-                    if (state == 0) {
-                        currentTop = y + width / 2f;
-                        state = 1;
-                    } else if (state == 2) {
-                        // bottom thin line, ignore and reset to expect next top
-                        state = 0;
-                    }
-                } else if (width == 3f) {
-                    if (state == 1 && !Float.isNaN(currentTop)) {
-                        float bottom = y - width / 2f;
-                        if (bottom > currentTop) {
-                            pairs.add(new float[]{currentTop, bottom});
+                if (line.contains("stroke-width=\"2\"") && line.contains("H800")) {
+                    int m = line.indexOf("M0 ");
+                    int h = line.indexOf("H800", m);
+                    if (m >= 0 && h >= 0) {
+                        try {
+                            ys.add(Float.parseFloat(line.substring(m + 3, h)));
+                        } catch (NumberFormatException ignored) {
                         }
-                        currentTop = Float.NaN;
-                        state = 2;
                     }
                 }
             }
         } catch (Exception ignored) {
+        }
+        java.util.Collections.sort(ys);
+        java.util.ArrayList<float[]> pairs = new java.util.ArrayList<>();
+        for (int i = 0; i + 1 < ys.size(); i += 2) {
+            float y1 = ys.get(i) + GUIDE_STROKE_WIDTH / 2f;
+            float y2 = ys.get(i + 1) - GUIDE_STROKE_WIDTH / 2f;
+            if (y2 > y1) {
+                pairs.add(new float[]{y1, y2});
+            }
         }
         return pairs.toArray(new float[0][]);
     }


### PR DESCRIPTION
## Summary
- Restore block range parsing to use pairs of thin guide lines
- Sort guide line coordinates before pairing so blocks respect top-bottom order
- Ensure blocks span entire line gaps instead of only the body zone

## Testing
- ✅ `xvfb-run -a --server-args="-screen 0 800x600x24" bash -lc 'LIBGL_ALWAYS_SOFTWARE=1 ./gradlew lwjgl3:run >/tmp/run.log & pid=$!; sleep 60; import -window root screenshot2.png; kill $pid; wait $pid; tail -n 20 /tmp/run.log'`
- ✅ `./gradlew core:test`


------
https://chatgpt.com/codex/tasks/task_e_68bbcd2e8528832a91e8d54fbf885076