### PR TITLE
Fix block vertical alignment on lined paper

### DIFF
--- a/core/src/main/java/tatar/eljah/hamsters/Main.java
+++ b/core/src/main/java/tatar/eljah/hamsters/Main.java
@@ -214,10 +214,12 @@ public class Main extends ApplicationAdapter {
         java.util.Collections.sort(ys);
         java.util.ArrayList<float[]> pairs = new java.util.ArrayList<>();
         for (int i = 0; i + 1 < ys.size(); i += 2) {
-            float y1 = ys.get(i) + GUIDE_STROKE_WIDTH;
-            float y2 = ys.get(i + 1) - GUIDE_STROKE_WIDTH;
-            if (y2 > y1) {
-                pairs.add(new float[]{y1, y2});
+            float topFromSvg = ys.get(i) + GUIDE_STROKE_WIDTH;
+            float bottomFromSvg = ys.get(i + 1) - GUIDE_STROKE_WIDTH;
+            if (bottomFromSvg > topFromSvg) {
+                float top = 600f - bottomFromSvg;
+                float bottom = 600f - topFromSvg;
+                pairs.add(new float[]{top, bottom});
             }
         }
         return pairs.toArray(new float[0][]);


### PR DESCRIPTION
## Summary
- Convert block guide coordinates from SVG's top-left origin to game's bottom-left origin

## Testing
- `xvfb-run -a ./gradlew --console=plain lwjgl3:run -Dheadless=true`

------
https://chatgpt.com/codex/tasks/task_e_68bd9b81bc5c832a99f03c787a0999d7