### PR TITLE
Fix hamster sprite overlapping by using collision box size

### DIFF
--- a/core/src/main/java/tatar/eljah/hamsters/Main.java
+++ b/core/src/main/java/tatar/eljah/hamsters/Main.java
@@ -547,7 +547,7 @@ public class Main extends ApplicationAdapter {
         batch.end();
 
         batch.begin();
-        batch.draw(hamsterTexture, hamster.x, hamster.y, 80, 80);
+        batch.draw(hamsterTexture, hamster.x, hamster.y, hamster.width, hamster.height);
         batch.draw(gradeTexture, grade.x, grade.y);
         for (Block block : blocks) {
             Rectangle body = block.body;


### PR DESCRIPTION
## Summary
- Render hamster sprite using its collision box dimensions to prevent visual overlap with lines and blocks

## Testing
- `./gradlew :core:test`


------
https://chatgpt.com/codex/tasks/task_e_68bdafd11a00832aa0b0724f2f90d6ea