### PR TITLE
Add block editor desktop tool

### DIFF
--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'application'
 
 sourceSets.main.resources.srcDirs += [ rootProject.file('assets').path ]
 
-mainClassName = 'tatar.eljah.hamsters.tools.ToolsLauncher'
+mainClassName = 'tatar.eljah.hamsters.tools.blockeditor.BlockEditorLauncher'
 application.setMainClass(mainClassName)
 
 eclipse.project.name = appName + '-tools'
@@ -17,4 +17,5 @@ dependencies {
     implementation "com.badlogicgames.gdx:gdx:$gdxVersion"
     implementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
     implementation "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
+    implementation "org.apache.xmlgraphics:batik-all:1.16"
 }

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/BlockEditorFrame.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/BlockEditorFrame.java
@@ -1,0 +1,148 @@
+package tatar.eljah.hamsters.tools.blockeditor;
+
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextField;
+import javax.swing.SwingConstants;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Locale;
+
+public class BlockEditorFrame extends JFrame {
+    private final BlockEditorPanel editorPanel;
+    private final JTextField scaleField;
+    private final JLabel statusLabel;
+    private File currentSvgFile;
+
+    public BlockEditorFrame() {
+        super("Block Editor");
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+        editorPanel = new BlockEditorPanel();
+        JScrollPane scrollPane = new JScrollPane(editorPanel);
+        scrollPane.setPreferredSize(new Dimension(1024, 600));
+        add(scrollPane, BorderLayout.CENTER);
+
+        statusLabel = new JLabel("Load an SVG to begin", SwingConstants.LEFT);
+
+        JPanel controls = new JPanel(new FlowLayout(FlowLayout.LEFT));
+
+        JButton loadButton = new JButton("Load SVG");
+        loadButton.addActionListener(this::onLoadSvg);
+        controls.add(loadButton);
+
+        controls.add(new JLabel("Scale:"));
+        scaleField = new JTextField("1.0", 6);
+        scaleField.addActionListener(e -> applyScale());
+        controls.add(scaleField);
+
+        JButton applyScale = new JButton("Apply");
+        applyScale.addActionListener(e -> applyScale());
+        controls.add(applyScale);
+
+        JButton resetPosition = new JButton("Center Vertically");
+        resetPosition.addActionListener(e -> {
+            statusLabel.setText(editorPanel.centerSvgVertically());
+        });
+        controls.add(resetPosition);
+
+        JButton addBody = new JButton("Add Body");
+        addBody.addActionListener(e -> statusLabel.setText(editorPanel.prepareRegionCreation(BlockRegionType.BODY)));
+        controls.add(addBody);
+
+        JButton addAsc = new JButton("Add Asc");
+        addAsc.addActionListener(e -> statusLabel.setText(editorPanel.prepareRegionCreation(BlockRegionType.ASCENDER)));
+        controls.add(addAsc);
+
+        JButton addDesc = new JButton("Add Desc");
+        addDesc.addActionListener(e -> statusLabel.setText(editorPanel.prepareRegionCreation(BlockRegionType.DESCENDER)));
+        controls.add(addDesc);
+
+        JButton remove = new JButton("Remove Selected");
+        remove.addActionListener(e -> statusLabel.setText(editorPanel.removeSelectedRegion()));
+        controls.add(remove);
+
+        JButton save = new JButton("Save");
+        save.addActionListener(this::onSave);
+        controls.add(save);
+
+        add(controls, BorderLayout.NORTH);
+
+        add(statusLabel, BorderLayout.SOUTH);
+
+        pack();
+        setLocationRelativeTo(null);
+    }
+
+    private void applyScale() {
+        try {
+            double scale = Double.parseDouble(scaleField.getText().trim().replace(',', '.'));
+            if (scale <= 0) {
+                throw new NumberFormatException("Scale must be positive");
+            }
+            if (!editorPanel.hasSvgLoaded()) {
+                JOptionPane.showMessageDialog(this, "Load an SVG before setting scale", "Warning", JOptionPane.WARNING_MESSAGE);
+                return;
+            }
+            editorPanel.setSvgScale(scale);
+            statusLabel.setText(String.format(Locale.US, "Scale set to %.3f", scale));
+        } catch (NumberFormatException ex) {
+            JOptionPane.showMessageDialog(this, "Invalid scale value", "Error", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void onLoadSvg(ActionEvent e) {
+        JFileChooser chooser = new JFileChooser();
+        chooser.setFileFilter(new FileNameExtensionFilter("SVG files", "svg"));
+        if (currentSvgFile != null) {
+            chooser.setCurrentDirectory(currentSvgFile.getParentFile());
+        }
+        if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+            File file = chooser.getSelectedFile();
+            try {
+                editorPanel.loadSvg(file);
+                currentSvgFile = file;
+                scaleField.setText(String.format(Locale.US, "%.3f", editorPanel.getSvgScale()));
+                statusLabel.setText("Loaded: " + file.getName());
+            } catch (IOException ioException) {
+                JOptionPane.showMessageDialog(this, "Failed to load SVG: " + ioException.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void onSave(ActionEvent e) {
+        if (!editorPanel.hasSvgLoaded() || currentSvgFile == null) {
+            JOptionPane.showMessageDialog(this, "Load an SVG before saving", "Warning", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+        try {
+            String svgFileName = currentSvgFile.getName();
+            String config = editorPanel.buildConfigurationJson(svgFileName);
+            Path targetDir = Paths.get("assets", "blocks");
+            Files.createDirectories(targetDir);
+            Path svgTarget = targetDir.resolve(svgFileName);
+            Files.copy(currentSvgFile.toPath(), svgTarget, StandardCopyOption.REPLACE_EXISTING);
+            String jsonName = svgFileName.replaceFirst("\\.svg$", "").concat(".json");
+            Path jsonTarget = targetDir.resolve(jsonName);
+            Files.write(jsonTarget, config.getBytes(StandardCharsets.UTF_8));
+            statusLabel.setText("Saved SVG and config to " + targetDir);
+        } catch (IOException ex) {
+            JOptionPane.showMessageDialog(this, "Failed to save: " + ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+}

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/BlockEditorLauncher.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/BlockEditorLauncher.java
@@ -1,0 +1,15 @@
+package tatar.eljah.hamsters.tools.blockeditor;
+
+import javax.swing.SwingUtilities;
+
+public final class BlockEditorLauncher {
+    private BlockEditorLauncher() {
+    }
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            BlockEditorFrame frame = new BlockEditorFrame();
+            frame.setVisible(true);
+        });
+    }
+}

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/BlockEditorPanel.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/BlockEditorPanel.java
@@ -1,0 +1,427 @@
+package tatar.eljah.hamsters.tools.blockeditor;
+
+import javax.imageio.ImageIO;
+import javax.swing.AbstractAction;
+import javax.swing.JPanel;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.RenderingHints;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+class BlockEditorPanel extends JPanel {
+    private final BufferedImage backgroundImage;
+    private SvgHandle svgHandle;
+    private Rectangle2D svgBounds;
+    private double svgScale = 1.0;
+    private double svgY = 0.0;
+
+    private final List<BlockRegion> ascenders = new ArrayList<>();
+    private final List<BlockRegion> descenders = new ArrayList<>();
+    private BlockRegion bodyRegion;
+    private BlockRegion selectedRegion;
+
+    private BlockRegionType creationType;
+    private Point creationStart;
+    private Rectangle2D.Double creationRect;
+
+    private boolean draggingSvg;
+    private int dragStartY;
+    private double initialSvgY;
+
+    private boolean draggingRegion;
+    private Point regionDragStart;
+    private Rectangle2D.Double regionInitialRect;
+
+    BlockEditorPanel() {
+        try (InputStream in = BlockEditorPanel.class.getResourceAsStream("/liner.png")) {
+            if (in == null) {
+                throw new IOException("Missing liner.png in assets");
+            }
+            backgroundImage = ImageIO.read(in);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load background", e);
+        }
+        setBackground(Color.WHITE);
+        setPreferredSize(new Dimension(backgroundImage.getWidth(), backgroundImage.getHeight()));
+        setFocusable(true);
+        MouseHandler mouseHandler = new MouseHandler();
+        addMouseListener(mouseHandler);
+        addMouseMotionListener(mouseHandler);
+
+        getInputMap(WHEN_FOCUSED).put(KeyStroke.getKeyStroke("DELETE"), "deleteRegion");
+        getActionMap().put("deleteRegion", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                removeSelectedRegion();
+            }
+        });
+    }
+
+    boolean hasSvgLoaded() {
+        return svgHandle != null;
+    }
+
+    double getSvgScale() {
+        return svgScale;
+    }
+
+    void loadSvg(File file) throws IOException {
+        svgHandle = SvgLoader.load(file);
+        svgBounds = svgHandle.getBounds();
+        svgScale = 1.0;
+        svgY = (backgroundImage.getHeight() - getSvgDrawHeight()) / 2.0;
+        creationType = null;
+        creationRect = null;
+        creationStart = null;
+        selectedRegion = null;
+        ascenders.clear();
+        descenders.clear();
+        bodyRegion = null;
+        repaint();
+    }
+
+    void setSvgScale(double scale) {
+        if (!hasSvgLoaded()) {
+            Toolkit.getDefaultToolkit().beep();
+            return;
+        }
+        double oldHeight = getSvgDrawHeight();
+        double centerY = svgY + oldHeight / 2.0;
+        svgScale = scale;
+        double newHeight = getSvgDrawHeight();
+        svgY = centerY - newHeight / 2.0;
+        clampSvgY();
+        repaint();
+    }
+
+    String centerSvgVertically() {
+        if (!hasSvgLoaded()) {
+            Toolkit.getDefaultToolkit().beep();
+            return "Load an SVG first";
+        }
+        svgY = (backgroundImage.getHeight() - getSvgDrawHeight()) / 2.0;
+        clampSvgY();
+        repaint();
+        return "SVG centered vertically";
+    }
+
+    String prepareRegionCreation(BlockRegionType type) {
+        if (!hasSvgLoaded()) {
+            Toolkit.getDefaultToolkit().beep();
+            return "Load an SVG first";
+        }
+        if (type == BlockRegionType.BODY && bodyRegion != null) {
+            Toolkit.getDefaultToolkit().beep();
+            return "Body region already exists";
+        }
+        creationType = type;
+        creationStart = null;
+        creationRect = null;
+        requestFocusInWindow();
+        return String.format(Locale.US, "Draw %s region by dragging", type.name().toLowerCase(Locale.US));
+    }
+
+    String removeSelectedRegion() {
+        if (selectedRegion == null) {
+            Toolkit.getDefaultToolkit().beep();
+            return "No region selected";
+        }
+        if (selectedRegion == bodyRegion) {
+            bodyRegion = null;
+        } else if (ascenders.remove(selectedRegion)) {
+            // removed from ascenders
+        } else {
+            descenders.remove(selectedRegion);
+        }
+        selectedRegion = null;
+        repaint();
+        return "Region removed";
+    }
+
+    void clearSelection() {
+        selectedRegion = null;
+        repaint();
+    }
+
+    String buildConfigurationJson(String svgFileName) {
+        if (!hasSvgLoaded()) {
+            throw new IllegalStateException("SVG not loaded");
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        sb.append(String.format(Locale.US, "  \"svg\": \"%s\",\n", svgFileName));
+        sb.append(String.format(Locale.US, "  \"scale\": %.5f,\n", svgScale));
+        sb.append(String.format(Locale.US, "  \"svgY\": %.5f,\n", svgY));
+        sb.append(String.format(Locale.US, "  \"canvasWidth\": %d,\n", backgroundImage.getWidth()));
+        sb.append(String.format(Locale.US, "  \"canvasHeight\": %d,\n", backgroundImage.getHeight()));
+        sb.append(String.format(Locale.US, "  \"svgBounds\": {\n    \"x\": %.5f,\n    \"y\": %.5f,\n    \"width\": %.5f,\n    \"height\": %.5f\n  },\n",
+                svgBounds.getX(), svgBounds.getY(), svgBounds.getWidth(), svgBounds.getHeight()));
+        sb.append("  \"body\": ");
+        if (bodyRegion != null) {
+            appendRectangle(sb, bodyRegion.getRect());
+        } else {
+            sb.append("null");
+        }
+        sb.append(",\n");
+        appendRegionArray(sb, "ascenders", ascenders);
+        sb.append(",\n");
+        appendRegionArray(sb, "descenders", descenders);
+        sb.append('\n');
+        sb.append("}\n");
+        return sb.toString();
+    }
+
+    private void appendRegionArray(StringBuilder sb, String name, List<BlockRegion> regions) {
+        sb.append("  \"").append(name).append("\": [");
+        if (!regions.isEmpty()) {
+            sb.append('\n');
+            for (int i = 0; i < regions.size(); i++) {
+                Rectangle2D.Double rect = regions.get(i).getRect();
+                sb.append("    ");
+                appendRectangle(sb, rect);
+                if (i < regions.size() - 1) {
+                    sb.append(',');
+                }
+                sb.append('\n');
+            }
+            sb.append("  ");
+        }
+        sb.append("]");
+    }
+
+    private void appendRectangle(StringBuilder sb, Rectangle2D.Double rect) {
+        sb.append(String.format(Locale.US,
+                "{\"x\": %.5f, \"y\": %.5f, \"width\": %.5f, \"height\": %.5f}",
+                rect.x, rect.y, rect.width, rect.height));
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return new Dimension(backgroundImage.getWidth(), backgroundImage.getHeight());
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        Graphics2D g2d = (Graphics2D) g.create();
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g2d.drawImage(backgroundImage, 0, 0, null);
+
+        if (hasSvgLoaded()) {
+            double svgWidth = getSvgDrawWidth();
+            double svgHeight = getSvgDrawHeight();
+            double svgX = (backgroundImage.getWidth() - svgWidth) / 2.0;
+
+            Graphics2D svgGraphics = (Graphics2D) g2d.create();
+            svgGraphics.translate(svgX, svgY);
+            svgGraphics.scale(svgScale, svgScale);
+            svgGraphics.translate(-svgBounds.getX(), -svgBounds.getY());
+            svgHandle.getGraphicsNode().paint(svgGraphics);
+            svgGraphics.dispose();
+
+            Rectangle2D svgOutline = new Rectangle2D.Double(svgX, svgY, svgWidth, svgHeight);
+            g2d.setColor(new Color(0, 0, 0, 80));
+            g2d.setStroke(new BasicStroke(1.2f));
+            g2d.draw(svgOutline);
+        }
+
+        if (bodyRegion != null) {
+            bodyRegion.draw(g2d, selectedRegion == bodyRegion);
+        }
+        for (BlockRegion region : ascenders) {
+            region.draw(g2d, selectedRegion == region);
+        }
+        for (BlockRegion region : descenders) {
+            region.draw(g2d, selectedRegion == region);
+        }
+
+        if (creationRect != null && creationType != null) {
+            Graphics2D tmp = (Graphics2D) g2d.create();
+            tmp.setColor(creationType.getBorderColor());
+            tmp.setStroke(new BasicStroke(1.2f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1f, new float[]{6f, 6f}, 0f));
+            tmp.draw(creationRect);
+            tmp.dispose();
+        }
+
+        g2d.dispose();
+    }
+
+    private double getSvgDrawWidth() {
+        if (svgBounds == null) {
+            return 0.0;
+        }
+        return svgBounds.getWidth() * svgScale;
+    }
+
+    private double getSvgDrawHeight() {
+        if (svgBounds == null) {
+            return 0.0;
+        }
+        return svgBounds.getHeight() * svgScale;
+    }
+
+    private Rectangle2D getSvgDrawBounds() {
+        double svgWidth = getSvgDrawWidth();
+        double svgHeight = getSvgDrawHeight();
+        double svgX = (backgroundImage.getWidth() - svgWidth) / 2.0;
+        return new Rectangle2D.Double(svgX, svgY, svgWidth, svgHeight);
+    }
+
+    private BlockRegion findRegionAt(Point point) {
+        if (bodyRegion != null && bodyRegion.getRect().contains(point)) {
+            return bodyRegion;
+        }
+        for (int i = ascenders.size() - 1; i >= 0; i--) {
+            BlockRegion region = ascenders.get(i);
+            if (region.getRect().contains(point)) {
+                return region;
+            }
+        }
+        for (int i = descenders.size() - 1; i >= 0; i--) {
+            BlockRegion region = descenders.get(i);
+            if (region.getRect().contains(point)) {
+                return region;
+            }
+        }
+        return null;
+    }
+
+    private void clampSvgY() {
+        double svgHeight = getSvgDrawHeight();
+        double minY = -svgHeight;
+        double maxY = backgroundImage.getHeight();
+        if (svgY < minY) {
+            svgY = minY;
+        }
+        if (svgY > maxY) {
+            svgY = maxY;
+        }
+    }
+
+    private void finalizeCreationRect() {
+        if (creationRect == null || creationType == null) {
+            return;
+        }
+        double width = Math.abs(creationRect.width);
+        double height = Math.abs(creationRect.height);
+        if (width < 2 || height < 2) {
+            creationRect = null;
+            creationStart = null;
+            return;
+        }
+        Rectangle2D.Double normalized = new Rectangle2D.Double(
+                Math.min(creationRect.x, creationRect.x + creationRect.width),
+                Math.min(creationRect.y, creationRect.y + creationRect.height),
+                width,
+                height);
+        BlockRegion region = new BlockRegion(creationType, normalized);
+        if (creationType == BlockRegionType.BODY) {
+            bodyRegion = region;
+            creationType = null;
+        } else if (creationType == BlockRegionType.ASCENDER) {
+            ascenders.add(region);
+        } else if (creationType == BlockRegionType.DESCENDER) {
+            descenders.add(region);
+        }
+        selectedRegion = region;
+        creationRect = null;
+        creationStart = null;
+        repaint();
+    }
+
+    private final class MouseHandler extends MouseAdapter {
+        @Override
+        public void mousePressed(MouseEvent e) {
+            requestFocusInWindow();
+            if (!SwingUtilities.isLeftMouseButton(e)) {
+                return;
+            }
+            Point point = e.getPoint();
+            if (creationType != null) {
+                creationStart = point;
+                creationRect = new Rectangle2D.Double(point.x, point.y, 0, 0);
+                return;
+            }
+
+            BlockRegion region = findRegionAt(point);
+            if (region != null) {
+                selectedRegion = region;
+                draggingRegion = true;
+                regionDragStart = point;
+                Rectangle2D.Double rect = region.getRect();
+                regionInitialRect = new Rectangle2D.Double(rect.x, rect.y, rect.width, rect.height);
+                repaint();
+                return;
+            }
+
+            if (hasSvgLoaded() && getSvgDrawBounds().contains(point)) {
+                draggingSvg = true;
+                dragStartY = point.y;
+                initialSvgY = svgY;
+            } else {
+                selectedRegion = null;
+                repaint();
+            }
+        }
+
+        @Override
+        public void mouseDragged(MouseEvent e) {
+            if (!SwingUtilities.isLeftMouseButton(e)) {
+                return;
+            }
+            Point point = e.getPoint();
+            if (creationType != null && creationRect != null && creationStart != null) {
+                creationRect.width = point.x - creationStart.x;
+                creationRect.height = point.y - creationStart.y;
+                repaint();
+                return;
+            }
+            if (draggingRegion && selectedRegion != null && regionInitialRect != null && regionDragStart != null) {
+                double dx = point.x - regionDragStart.x;
+                double dy = point.y - regionDragStart.y;
+                Rectangle2D.Double rect = selectedRegion.getRect();
+                rect.x = regionInitialRect.x + dx;
+                rect.y = regionInitialRect.y + dy;
+                repaint();
+                return;
+            }
+            if (draggingSvg) {
+                double dy = point.y - dragStartY;
+                svgY = initialSvgY + dy;
+                clampSvgY();
+                repaint();
+            }
+        }
+
+        @Override
+        public void mouseReleased(MouseEvent e) {
+            if (!SwingUtilities.isLeftMouseButton(e)) {
+                return;
+            }
+            if (creationType != null && creationRect != null) {
+                finalizeCreationRect();
+            }
+            draggingSvg = false;
+            draggingRegion = false;
+            regionInitialRect = null;
+            regionDragStart = null;
+        }
+    }
+}

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/BlockRegion.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/BlockRegion.java
@@ -1,0 +1,43 @@
+package tatar.eljah.hamsters.tools.blockeditor;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.geom.Rectangle2D;
+
+public class BlockRegion {
+    private final BlockRegionType type;
+    private final Rectangle2D.Double rect;
+
+    public BlockRegion(BlockRegionType type, Rectangle2D.Double rect) {
+        this.type = type;
+        this.rect = rect;
+    }
+
+    public BlockRegionType getType() {
+        return type;
+    }
+
+    public Rectangle2D.Double getRect() {
+        return rect;
+    }
+
+    public void translate(double dx, double dy) {
+        rect.x += dx;
+        rect.y += dy;
+    }
+
+    public void draw(Graphics2D g2d, boolean selected) {
+        Color fill = type.getFillColor();
+        Color border = type.getBorderColor();
+        g2d.setColor(fill);
+        g2d.fill(rect);
+        g2d.setColor(border);
+        g2d.setStroke(new BasicStroke(selected ? 3f : 1.5f));
+        g2d.draw(rect);
+    }
+
+    public BlockRegion copy() {
+        return new BlockRegion(type, new Rectangle2D.Double(rect.x, rect.y, rect.width, rect.height));
+    }
+}

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/BlockRegionType.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/BlockRegionType.java
@@ -1,0 +1,25 @@
+package tatar.eljah.hamsters.tools.blockeditor;
+
+import java.awt.Color;
+
+public enum BlockRegionType {
+    BODY(new Color(204, 0, 0, 120), new Color(204, 0, 0)),
+    ASCENDER(new Color(0, 128, 0, 120), new Color(0, 128, 0)),
+    DESCENDER(new Color(0, 0, 204, 120), new Color(0, 0, 204));
+
+    private final Color fillColor;
+    private final Color borderColor;
+
+    BlockRegionType(Color fillColor, Color borderColor) {
+        this.fillColor = fillColor;
+        this.borderColor = borderColor;
+    }
+
+    public Color getFillColor() {
+        return fillColor;
+    }
+
+    public Color getBorderColor() {
+        return borderColor;
+    }
+}

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/SvgHandle.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/SvgHandle.java
@@ -1,0 +1,23 @@
+package tatar.eljah.hamsters.tools.blockeditor;
+
+import org.apache.batik.gvt.GraphicsNode;
+
+import java.awt.geom.Rectangle2D;
+
+final class SvgHandle {
+    private final GraphicsNode graphicsNode;
+    private final Rectangle2D bounds;
+
+    SvgHandle(GraphicsNode graphicsNode, Rectangle2D bounds) {
+        this.graphicsNode = graphicsNode;
+        this.bounds = bounds;
+    }
+
+    GraphicsNode getGraphicsNode() {
+        return graphicsNode;
+    }
+
+    Rectangle2D getBounds() {
+        return bounds;
+    }
+}

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/SvgLoader.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/SvgLoader.java
@@ -1,0 +1,45 @@
+package tatar.eljah.hamsters.tools.blockeditor;
+
+import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
+import org.apache.batik.bridge.BridgeContext;
+import org.apache.batik.bridge.DocumentLoader;
+import org.apache.batik.bridge.GVTBuilder;
+import org.apache.batik.bridge.UserAgentAdapter;
+import org.apache.batik.gvt.GraphicsNode;
+import org.apache.batik.util.XMLResourceDescriptor;
+import org.w3c.dom.svg.SVGDocument;
+
+import java.awt.geom.Rectangle2D;
+import java.io.File;
+import java.io.IOException;
+
+final class SvgLoader {
+    private SvgLoader() {
+    }
+
+    static SvgHandle load(File file) throws IOException {
+        String parser = XMLResourceDescriptor.getXMLParserClassName();
+        SAXSVGDocumentFactory factory = new SAXSVGDocumentFactory(parser);
+        SVGDocument document = factory.createSVGDocument(file.toURI().toString());
+
+        UserAgentAdapter userAgent = new UserAgentAdapter();
+        DocumentLoader loader = new DocumentLoader(userAgent);
+        BridgeContext context = new BridgeContext(userAgent, loader);
+        context.setDynamicState(BridgeContext.STATIC);
+
+        GVTBuilder builder = new GVTBuilder();
+        GraphicsNode node = builder.build(context, document);
+
+        Rectangle2D bounds = node.getPrimitiveBounds();
+        if (bounds == null) {
+            bounds = node.getBounds();
+        }
+        if (bounds == null) {
+            bounds = new Rectangle2D.Double(0, 0, 0, 0);
+        }
+        loader.dispose();
+        context.dispose();
+
+        return new SvgHandle(node, bounds);
+    }
+}


### PR DESCRIPTION
## Summary
- add a Swing-based block editor that loads the ruled background, centers SVG artwork, and supports scaling plus vertical dragging
- enable creation and management of body, ascender, and descender regions with configuration export to JSON alongside the SVG asset
- switch the tools launcher to the new editor and add Apache Batik dependencies for SVG rendering support

## Testing
- ./gradlew --console=plain :tools:build

------
https://chatgpt.com/codex/tasks/task_e_68de77d44728832a9ea8bda24ed5d8cb