### PR TITLE
Handle liner background fallback

### DIFF
--- a/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/SvgLoader.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/SvgLoader.java
@@ -12,6 +12,7 @@ import org.w3c.dom.svg.SVGDocument;
 import java.awt.geom.Rectangle2D;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 
 final class SvgLoader {
     private SvgLoader() {
@@ -21,25 +22,38 @@ final class SvgLoader {
         String parser = XMLResourceDescriptor.getXMLParserClassName();
         SAXSVGDocumentFactory factory = new SAXSVGDocumentFactory(parser);
         SVGDocument document = factory.createSVGDocument(file.toURI().toString());
+        return buildHandle(document);
+    }
 
+    static SvgHandle load(InputStream inputStream, String documentUri) throws IOException {
+        String parser = XMLResourceDescriptor.getXMLParserClassName();
+        SAXSVGDocumentFactory factory = new SAXSVGDocumentFactory(parser);
+        SVGDocument document = factory.createSVGDocument(documentUri, inputStream);
+        return buildHandle(document);
+    }
+
+    private static SvgHandle buildHandle(SVGDocument document) {
         UserAgentAdapter userAgent = new UserAgentAdapter();
         DocumentLoader loader = new DocumentLoader(userAgent);
         BridgeContext context = new BridgeContext(userAgent, loader);
         context.setDynamicState(BridgeContext.STATIC);
 
-        GVTBuilder builder = new GVTBuilder();
-        GraphicsNode node = builder.build(context, document);
+        try {
+            GVTBuilder builder = new GVTBuilder();
+            GraphicsNode node = builder.build(context, document);
 
-        Rectangle2D bounds = node.getPrimitiveBounds();
-        if (bounds == null) {
-            bounds = node.getBounds();
-        }
-        if (bounds == null) {
-            bounds = new Rectangle2D.Double(0, 0, 0, 0);
-        }
-        loader.dispose();
-        context.dispose();
+            Rectangle2D bounds = node.getPrimitiveBounds();
+            if (bounds == null) {
+                bounds = node.getBounds();
+            }
+            if (bounds == null) {
+                bounds = new Rectangle2D.Double(0, 0, 0, 0);
+            }
 
-        return new SvgHandle(node, bounds);
+            return new SvgHandle(node, bounds);
+        } finally {
+            loader.dispose();
+            context.dispose();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow the block editor to load its background from liner.png when present and fall back to liner.svg otherwise
- add an SvgLoader overload that can read from input streams so the SVG background can be rasterized for the editor

## Testing
- ./gradlew :tools:compileJava

------
https://chatgpt.com/codex/tasks/task_e_68ded4d41064832a9f6a5e84672cdda6