### PR TITLE
Fix HTML build by removing unsupported Java APIs

### DIFF
--- a/core/src/main/java/io/github/fxzjshm/gdx/svg2pixmap/BallpointPenRenderer.java
+++ b/core/src/main/java/io/github/fxzjshm/gdx/svg2pixmap/BallpointPenRenderer.java
@@ -2,8 +2,6 @@ package io.github.fxzjshm.gdx.svg2pixmap;
 
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.graphics.PixmapIO;
-import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.math.MathUtils;
 
 import tatar.eljah.hamsters.Main;
@@ -14,9 +12,8 @@ import tatar.eljah.hamsters.Main;
  * The class converts an SVG into a {@link Pixmap} using {@link Svg2Pixmap}, applies
  * the existing {@link Main#applyBallpointEffect(Pixmap)} to soften edges, then adds
  * deterministic colour and transparency jitter so that the result resembles a
- * hand‑drawn ballpoint pen line. The produced pixmap can optionally be written
- * to a PNG file.
- */
+ * hand‑drawn ballpoint pen line.
+*/
 public class BallpointPenRenderer {
 
     /** Base colour of the ballpoint pen (a darker blue matching real ink). */
@@ -39,20 +36,6 @@ public class BallpointPenRenderer {
         Main.applyBallpointEffect(pixmap);
         applyInkNoise(pixmap);
         return pixmap;
-    }
-
-    /**
-     * Render the SVG and immediately write the result to a PNG file.
-     *
-     * @param svg    SVG string.
-     * @param width  width of the target image.
-     * @param height height of the target image.
-     * @param output where to write the PNG.
-     */
-    public static void renderToFile(String svg, int width, int height, FileHandle output) {
-        Pixmap pixmap = render(svg, width, height);
-        PixmapIO.writePNG(output, pixmap);
-        pixmap.dispose();
     }
 
     /**

--- a/core/src/main/java/tatar/eljah/hamsters/Main.gwt.xml
+++ b/core/src/main/java/tatar/eljah/hamsters/Main.gwt.xml
@@ -2,7 +2,9 @@
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.11.0//EN" "https://www.gwtproject.org/doctype/2.11.0/gwt-module.dtd">
 <module>
   <!-- Paths to source are relative to this file and separated by slashes ('/'). -->
-  <source path="" />
+  <source path="">
+    <exclude name="PixmapCache.java" />
+  </source>
   <!-- Reflection includes may be needed for your code or library code. Each value is separated by periods ('.'). -->
   <!-- You can include a full package by not including the name of a type at the end. -->
 

--- a/core/src/main/java/tatar/eljah/hamsters/PixmapCache.java
+++ b/core/src/main/java/tatar/eljah/hamsters/PixmapCache.java
@@ -1,0 +1,34 @@
+package tatar.eljah.hamsters;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.PixmapIO;
+
+/**
+ * Platform-specific helpers for caching pixmaps as PNG files.
+ */
+public final class PixmapCache {
+    private PixmapCache() {
+    }
+
+    static boolean isSupported() {
+        return true;
+    }
+
+    static Pixmap load(FileHandle file) {
+        return new Pixmap(file);
+    }
+
+    static void save(FileHandle file, Pixmap pixmap) {
+        PixmapIO.writePNG(file, pixmap);
+    }
+
+    static FileHandle resolveCacheDir() {
+        String tmp = System.getProperty("java.io.tmpdir");
+        FileHandle base = tmp != null ? Gdx.files.absolute(tmp) : Gdx.files.local(".");
+        FileHandle dir = base.child("hamstersgame-cache");
+        dir.mkdirs();
+        return dir;
+    }
+}

--- a/html/src/main/java/tatar/eljah/hamsters/GdxDefinition.gwt.xml
+++ b/html/src/main/java/tatar/eljah/hamsters/GdxDefinition.gwt.xml
@@ -3,6 +3,7 @@
 <module rename-to="html">
   <!-- Paths to source are relative to this file and separated by slashes ('/'). -->
   <source path="" />
+  <super-source path="super" />
 
   <!-- Reflection includes may be needed for your code or library code. Each value is separated by periods ('.'). -->
   <!-- You can include a full package by not including the name of a type at the end. -->

--- a/html/src/main/java/tatar/eljah/hamsters/super/tatar/eljah/hamsters/PixmapCache.java
+++ b/html/src/main/java/tatar/eljah/hamsters/super/tatar/eljah/hamsters/PixmapCache.java
@@ -1,0 +1,29 @@
+package tatar.eljah.hamsters;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Pixmap;
+
+/**
+ * GWT backend does not support pixmap disk caching.
+ */
+public final class PixmapCache {
+    private PixmapCache() {
+    }
+
+    static boolean isSupported() {
+        return false;
+    }
+
+    static Pixmap load(FileHandle file) {
+        throw new UnsupportedOperationException("Pixmap caching is not supported on GWT");
+    }
+
+    static void save(FileHandle file, Pixmap pixmap) {
+        // No-op
+    }
+
+    static FileHandle resolveCacheDir() {
+        return Gdx.files.local("hamstersgame-cache");
+    }
+}


### PR DESCRIPTION
## Summary
- load SVG-derived textures sequentially, add manual hex formatting, and avoid unsupported System properties during HTML builds
- add a PixmapCache helper with a GWT super-source variant and update module descriptors to exclude the desktop implementation
- drop the unused PixmapIO helper from BallpointPenRenderer so the HTML target no longer depends on missing classes

## Testing
- ./gradlew html:dist
- ./gradlew build *(fails: Android SDK not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68decf5194a4832a9ae80dadd6b3c9da