### PR TITLE
Handle BlockEditor background when liner.png is missing

### DIFF
--- a/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/SvgLoader.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/SvgLoader.java
@@ -18,10 +18,17 @@ final class SvgLoader {
     }
 
     static SvgHandle load(File file) throws IOException {
+        return load(file.toURI().toString());
+    }
+
+    static SvgHandle load(String uri) throws IOException {
         String parser = XMLResourceDescriptor.getXMLParserClassName();
         SAXSVGDocumentFactory factory = new SAXSVGDocumentFactory(parser);
-        SVGDocument document = factory.createSVGDocument(file.toURI().toString());
+        SVGDocument document = factory.createSVGDocument(uri);
+        return buildHandle(document);
+    }
 
+    private static SvgHandle buildHandle(SVGDocument document) throws IOException {
         UserAgentAdapter userAgent = new UserAgentAdapter();
         DocumentLoader loader = new DocumentLoader(userAgent);
         BridgeContext context = new BridgeContext(userAgent, loader);


### PR DESCRIPTION
## Summary
- load the block editor background through a helper that first tries liner.png and then rasterizes liner.svg when needed
- extend `SvgLoader` with a URI-based loader so SVG assets bundled in the classpath can be consumed without temporary files

## Testing
- `./gradlew --console=plain :tools:classes > gradle.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_68ded81f82c4832ab78eb23df53bba0d