### PR TITLE
Fix html dev server resource base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Useful Gradle tasks and flags:
 - `clean`: removes `build` folders, which store compiled classes and built archives.
 - `eclipse`: generates Eclipse project data.
 - `html:dist`: compiles GWT sources. The compiled application can be found at `html/build/dist`: you can use any HTTP server to deploy it.
+- `html:beforeRun`: prepares and launches the Jetty dev server together with the SuperDev code server. By default it binds to port `8087`. If that port is already taken on your machine (the build will fail with `Failed to bind to /0.0.0.0:8087`), pass another value with `./gradlew html:beforeRun -PhtmlDevPort=8090` or set `HTML_DEV_PORT` in the environment. The task reuses the GWT draft output directory (`html/build/gwt/draftOut`), so the hashed PNGs and other preloader assets produced by `draftCompileGwt` end up under `assets/` and can be served to the browser.
 - `html:superDev`: compiles GWT sources and runs the application in SuperDev mode. It will be available at [localhost:8080/html](http://localhost:8080/html). Use only during development.
 - `idea`: generates IntelliJ project data.
 - `lwjgl3:jar`: builds application's runnable jar, which can be found at `lwjgl3/build/libs`.

--- a/html/build.gradle
+++ b/html/build.gradle
@@ -44,14 +44,16 @@ dependencies {
 import org.akhikhl.gretty.AppBeforeIntegrationTestTask
 import org.docstr.gradle.plugins.gwt.GwtSuperDev
 
-gretty.httpPort = 8087
+def requestedHttpPort = (findProperty('htmlDevPort') ?: System.getenv('HTML_DEV_PORT'))
+gretty.httpPort = requestedHttpPort ? requestedHttpPort.toInteger() : 8087
 // The line below will need to be changed only if you change the build directory to something other than "build".
-gretty.resourceBase = "${project.layout.buildDirectory.asFile.get().absolutePath}\\gwt\\draftOut"
+gretty.resourceBase = project.layout.buildDirectory.dir('gwt/draftOut').get().asFile.absolutePath
 gretty.contextPath = "/"
 gretty.portPropertiesFileName = "TEMP_PORTS.properties"
 
 task startHttpServer (dependsOn: [draftCompileGwt]) {
   doFirst {
+    file(gretty.resourceBase).mkdirs()
     copy {
       from "webapp"
       into gretty.resourceBase


### PR DESCRIPTION
## Summary
- fix Gretty's resource base so the GWT dev server uses the correct draft output directory on Unix-like systems
- document that html:beforeRun copies the hashed preloader assets generated during draftCompileGwt

## Testing
- ./gradlew html:beforeRun -PhtmlDevPort=8095 --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68deea0975c4832a98b74c63df03e7b8