### PR TITLE
Remove generated PNG fallbacks from HTML build

### DIFF
--- a/core/src/main/java/io/github/fxzjshm/gdx/svg2pixmap/Svg2Pixmap.java
+++ b/core/src/main/java/io/github/fxzjshm/gdx/svg2pixmap/Svg2Pixmap.java
@@ -522,9 +522,12 @@ public class Svg2Pixmap {
         ellipse(element, pixmap, 1f, 1f, 0f, 0f);
     }
 
+    private static boolean warnedGwt;
+
     protected static void checkGWT() {
-        if (Gdx.app.getType().equals(Application.ApplicationType.WebGL)) {
-            Gdx.app.error("Svg2Pixmap", "Due to performance issue, in GWT mode please use functions with suffix -JSNI instead.");
+        if (!warnedGwt && Gdx.app != null && Gdx.app.getType() == Application.ApplicationType.WebGL) {
+            Gdx.app.log("Svg2Pixmap", "Falling back to CPU SVG rasterization; consider using the JSNI helpers for async conversion in GWT.");
+            warnedGwt = true;
         }
     }
 

--- a/core/src/main/java/tatar/eljah/hamsters/Main.java
+++ b/core/src/main/java/tatar/eljah/hamsters/Main.java
@@ -1,5 +1,6 @@
 package tatar.eljah.hamsters;
 
+import com.badlogic.gdx.Application;
 import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
@@ -63,6 +64,10 @@ public class Main extends ApplicationAdapter {
 
     @Override
     public void create() {
+        if (Gdx.app.getType() == Application.ApplicationType.WebGL) {
+            Svg2Pixmap.generateScale = 1;
+        }
+
         batch = new SpriteBatch();
         font = new BitmapFont();
         shapeRenderer = new ShapeRenderer();
@@ -80,7 +85,9 @@ public class Main extends ApplicationAdapter {
 
         loading = true;
         loadingProgress = 0f;
-        cacheDir = PixmapCache.resolveCacheDir();
+        if (PixmapCache.isSupported()) {
+            cacheDir = PixmapCache.resolveCacheDir();
+        }
 
         int completed = 0;
         int total = 4;
@@ -127,6 +134,7 @@ public class Main extends ApplicationAdapter {
         controlRenderer = new OnscreenControlRenderer();
         resetGame();
         loading = false;
+        Gdx.app.log("Main", "Assets loaded");
     }
 
     private void calculateCorridors() {
@@ -221,6 +229,11 @@ public class Main extends ApplicationAdapter {
     }
 
     private Pixmap loadCachedSvg(String name, String svg, int width, int height) {
+        if (Gdx.app.getType() == Application.ApplicationType.WebGL) {
+            // The HTML backend cannot access the desktop cache, but CPU rasterization works reliably.
+            return Svg2Pixmap.svg2Pixmap(svg, width, height);
+        }
+
         if (PixmapCache.isSupported()) {
             String hash = md5(svg + width + "x" + height);
             FileHandle file = cacheDir.child(name + "-" + hash + ".png");

--- a/html/src/main/java/tatar/eljah/hamsters/super/tatar/eljah/hamsters/PixmapCache.java
+++ b/html/src/main/java/tatar/eljah/hamsters/super/tatar/eljah/hamsters/PixmapCache.java
@@ -1,6 +1,5 @@
 package tatar.eljah.hamsters;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Pixmap;
 
@@ -24,6 +23,6 @@ public final class PixmapCache {
     }
 
     static FileHandle resolveCacheDir() {
-        return Gdx.files.local("hamstersgame-cache");
+        throw new UnsupportedOperationException("Pixmap caching is not supported on GWT");
     }
 }


### PR DESCRIPTION
## Summary
- stop shipping the pre-rendered *_web.png assets and clean up the asset manifest entries
- have the WebGL build rasterize the SVGs directly instead of loading the deleted PNG fallbacks while keeping desktop caching behavior

## Testing
- ./gradlew --console=plain html:draftCompileGwt

------
https://chatgpt.com/codex/tasks/task_e_68def4768098832a994f66db58cca6c0