### PR TITLE
Add scene editor for assembling annotated blocks

### DIFF
--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'application'
 
 sourceSets.main.resources.srcDirs += [ rootProject.file('assets').path ]
 
-mainClassName = 'tatar.eljah.hamsters.tools.blockeditor.BlockEditorLauncher'
-application.setMainClass(mainClassName)
+def defaultMainClass = 'tatar.eljah.hamsters.tools.blockeditor.BlockEditorLauncher'
+def chosenMainClass = project.hasProperty('mainClass') ? project.property('mainClass').toString() : defaultMainClass
+mainClassName = chosenMainClass
+application.setMainClass(chosenMainClass)
 
 eclipse.project.name = appName + '-tools'
 

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/BlockEditorPanel.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/BlockEditorPanel.java
@@ -1,5 +1,8 @@
 package tatar.eljah.hamsters.tools.blockeditor;
 
+import tatar.eljah.hamsters.tools.svg.SvgHandle;
+import tatar.eljah.hamsters.tools.svg.SvgLoader;
+
 import javax.imageio.ImageIO;
 import javax.swing.AbstractAction;
 import javax.swing.JPanel;

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/BlockDefinition.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/BlockDefinition.java
@@ -1,0 +1,228 @@
+package tatar.eljah.hamsters.tools.sceneeditor;
+
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.utils.JsonReader;
+import com.badlogic.gdx.utils.JsonValue;
+import tatar.eljah.hamsters.tools.svg.SvgHandle;
+import tatar.eljah.hamsters.tools.svg.SvgLoader;
+
+import java.awt.geom.Rectangle2D;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+final class BlockDefinition {
+    private final String jsonFileName;
+    private final String displayName;
+    private final SvgHandle svgHandle;
+    private final Rectangle2D svgBounds;
+    private final double svgScale;
+    private final double svgY;
+    private final int canvasWidth;
+    private final int canvasHeight;
+    private final Rectangle2D.Double bodyRect;
+    private final List<Rectangle2D.Double> ascenders;
+    private final List<Rectangle2D.Double> descenders;
+    private final Rectangle2D.Double contentBounds;
+    private final double svgDrawX;
+
+    private BlockDefinition(String jsonFileName,
+                            String displayName,
+                            SvgHandle svgHandle,
+                            Rectangle2D svgBounds,
+                            double svgScale,
+                            double svgY,
+                            int canvasWidth,
+                            int canvasHeight,
+                            Rectangle2D.Double bodyRect,
+                            List<Rectangle2D.Double> ascenders,
+                            List<Rectangle2D.Double> descenders,
+                            Rectangle2D.Double contentBounds,
+                            double svgDrawX) {
+        this.jsonFileName = jsonFileName;
+        this.displayName = displayName;
+        this.svgHandle = svgHandle;
+        this.svgBounds = svgBounds;
+        this.svgScale = svgScale;
+        this.svgY = svgY;
+        this.canvasWidth = canvasWidth;
+        this.canvasHeight = canvasHeight;
+        this.bodyRect = bodyRect;
+        this.ascenders = ascenders;
+        this.descenders = descenders;
+        this.contentBounds = contentBounds;
+        this.svgDrawX = svgDrawX;
+    }
+
+    static BlockDefinition load(File jsonFile) throws IOException {
+        JsonReader reader = new JsonReader();
+        JsonValue root = reader.parse(new FileHandle(jsonFile));
+        String svgFileName = root.getString("svg");
+        File svgFile = new File(jsonFile.getParentFile(), svgFileName);
+        if (!svgFile.isFile()) {
+            throw new IOException("SVG file not found for block: " + svgFile.getAbsolutePath());
+        }
+        SvgHandle handle = SvgLoader.load(svgFile);
+        Rectangle2D svgBounds = handle.getBounds();
+        double svgScale = root.getDouble("scale", 1.0);
+        double svgY = root.getDouble("svgY", 0.0);
+        int canvasWidth = root.getInt("canvasWidth", 800);
+        int canvasHeight = root.getInt("canvasHeight", 600);
+        JsonValue boundsValue = root.get("svgBounds");
+        if (boundsValue != null) {
+            double x = boundsValue.getDouble("x", svgBounds.getX());
+            double y = boundsValue.getDouble("y", svgBounds.getY());
+            double width = boundsValue.getDouble("width", svgBounds.getWidth());
+            double height = boundsValue.getDouble("height", svgBounds.getHeight());
+            svgBounds = new Rectangle2D.Double(x, y, width, height);
+        }
+
+        Rectangle2D.Double bodyRect = null;
+        JsonValue bodyValue = root.get("body");
+        if (bodyValue != null && !bodyValue.isNull()) {
+            bodyRect = readRectangle(bodyValue);
+        }
+
+        List<Rectangle2D.Double> ascenders = readRectangles(root.get("ascenders"));
+        List<Rectangle2D.Double> descenders = readRectangles(root.get("descenders"));
+
+        Rectangle2D.Double contentBounds = computeContentBounds(bodyRect, ascenders, descenders);
+        double svgDrawWidth = svgBounds.getWidth() * svgScale;
+        double svgDrawX = (canvasWidth - svgDrawWidth) / 2.0;
+        if (contentBounds == null) {
+            contentBounds = new Rectangle2D.Double(svgDrawX, svgY, svgDrawWidth, svgBounds.getHeight() * svgScale);
+        }
+
+        String jsonName = jsonFile.getName();
+        String displayName = stripExtension(jsonName);
+        return new BlockDefinition(
+                jsonName,
+                displayName,
+                handle,
+                svgBounds,
+                svgScale,
+                svgY,
+                canvasWidth,
+                canvasHeight,
+                bodyRect,
+                Collections.unmodifiableList(ascenders),
+                Collections.unmodifiableList(descenders),
+                contentBounds,
+                svgDrawX
+        );
+    }
+
+    private static Rectangle2D.Double readRectangle(JsonValue value) {
+        double x = value.getDouble("x", 0.0);
+        double y = value.getDouble("y", 0.0);
+        double width = value.getDouble("width", 0.0);
+        double height = value.getDouble("height", 0.0);
+        return new Rectangle2D.Double(x, y, width, height);
+    }
+
+    private static List<Rectangle2D.Double> readRectangles(JsonValue array) {
+        if (array == null || array.isNull()) {
+            return Collections.emptyList();
+        }
+        List<Rectangle2D.Double> list = new ArrayList<>();
+        for (JsonValue child : array) {
+            list.add(readRectangle(child));
+        }
+        return list;
+    }
+
+    private static Rectangle2D.Double computeContentBounds(Rectangle2D.Double body,
+                                                            List<Rectangle2D.Double> ascenders,
+                                                            List<Rectangle2D.Double> descenders) {
+        Rectangle2D.Double bounds = null;
+        if (body != null) {
+            bounds = new Rectangle2D.Double(body.x, body.y, body.width, body.height);
+        }
+        bounds = extend(bounds, ascenders);
+        bounds = extend(bounds, descenders);
+        return bounds;
+    }
+
+    private static Rectangle2D.Double extend(Rectangle2D.Double base, List<Rectangle2D.Double> additions) {
+        Rectangle2D.Double result = base;
+        for (Rectangle2D.Double rect : additions) {
+            if (result == null) {
+                result = new Rectangle2D.Double(rect.x, rect.y, rect.width, rect.height);
+            } else {
+                double minX = Math.min(result.x, rect.x);
+                double minY = Math.min(result.y, rect.y);
+                double maxX = Math.max(result.x + result.width, rect.x + rect.width);
+                double maxY = Math.max(result.y + result.height, rect.y + rect.height);
+                result = new Rectangle2D.Double(minX, minY, maxX - minX, maxY - minY);
+            }
+        }
+        return result;
+    }
+
+    private static String stripExtension(String name) {
+        int dotIndex = name.lastIndexOf('.');
+        if (dotIndex > 0) {
+            return name.substring(0, dotIndex);
+        }
+        return name;
+    }
+
+    String getJsonFileName() {
+        return jsonFileName;
+    }
+
+    String getDisplayName() {
+        return displayName;
+    }
+
+    SvgHandle getSvgHandle() {
+        return svgHandle;
+    }
+
+    Rectangle2D getSvgBounds() {
+        return svgBounds;
+    }
+
+    double getSvgScale() {
+        return svgScale;
+    }
+
+    double getSvgY() {
+        return svgY;
+    }
+
+    int getCanvasWidth() {
+        return canvasWidth;
+    }
+
+    int getCanvasHeight() {
+        return canvasHeight;
+    }
+
+    Rectangle2D.Double getBodyRect() {
+        return bodyRect;
+    }
+
+    List<Rectangle2D.Double> getAscenders() {
+        return ascenders;
+    }
+
+    List<Rectangle2D.Double> getDescenders() {
+        return descenders;
+    }
+
+    Rectangle2D.Double getContentBounds() {
+        return contentBounds;
+    }
+
+    double getSvgDrawX() {
+        return svgDrawX;
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+}

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/BlockInstance.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/BlockInstance.java
@@ -1,0 +1,65 @@
+package tatar.eljah.hamsters.tools.sceneeditor;
+
+import java.awt.geom.Rectangle2D;
+
+final class BlockInstance {
+    private final String blockReference;
+    private BlockDefinition definition;
+    private double x;
+    private double y;
+
+    BlockInstance(BlockDefinition definition, double x, double y) {
+        this.blockReference = definition.getJsonFileName();
+        this.definition = definition;
+        this.x = x;
+        this.y = y;
+    }
+
+    String getBlockReference() {
+        return blockReference;
+    }
+
+    BlockDefinition getDefinition() {
+        return definition;
+    }
+
+    void setDefinition(BlockDefinition definition) {
+        this.definition = definition;
+    }
+
+    double getX() {
+        return x;
+    }
+
+    double getY() {
+        return y;
+    }
+
+    void setPosition(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    void setY(double y) {
+        this.y = y;
+    }
+
+    Rectangle2D.Double getBoundingBox() {
+        if (definition == null) {
+            return new Rectangle2D.Double(x, y, 0, 0);
+        }
+        Rectangle2D.Double base = definition.getContentBounds();
+        return new Rectangle2D.Double(base.x + x, base.y + y, base.width, base.height);
+    }
+
+    Rectangle2D.Double getBodyBounds() {
+        if (definition == null) {
+            return null;
+        }
+        Rectangle2D.Double body = definition.getBodyRect();
+        if (body == null) {
+            return null;
+        }
+        return new Rectangle2D.Double(body.x + x, body.y + y, body.width, body.height);
+    }
+}

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/LinerGuides.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/LinerGuides.java
@@ -1,0 +1,140 @@
+package tatar.eljah.hamsters.tools.sceneeditor;
+
+import tatar.eljah.hamsters.tools.svg.SvgHandle;
+import tatar.eljah.hamsters.tools.svg.SvgLoader;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class LinerGuides {
+    private static final Pattern HORIZONTAL_LINE_PATTERN = Pattern.compile("M0\\s+([0-9.]+)H800");
+
+    private final BufferedImage backgroundImage;
+    private final List<BodyStripe> bodyStripes;
+    private final String backgroundAssetName;
+
+    private LinerGuides(BufferedImage backgroundImage, List<BodyStripe> bodyStripes, String backgroundAssetName) {
+        this.backgroundImage = backgroundImage;
+        this.bodyStripes = bodyStripes;
+        this.backgroundAssetName = backgroundAssetName;
+    }
+
+    static LinerGuides load() throws IOException {
+        BufferedImage background = loadBackgroundImage();
+        List<BodyStripe> stripes = parseBodyStripes();
+        return new LinerGuides(background, stripes, "liner.svg");
+    }
+
+    BufferedImage getBackgroundImage() {
+        return backgroundImage;
+    }
+
+    List<BodyStripe> getBodyStripes() {
+        return bodyStripes;
+    }
+
+    String getBackgroundAssetName() {
+        return backgroundAssetName;
+    }
+
+    private static BufferedImage loadBackgroundImage() throws IOException {
+        try (InputStream pngStream = LinerGuides.class.getResourceAsStream("/liner.png")) {
+            if (pngStream != null) {
+                BufferedImage image = ImageIO.read(pngStream);
+                if (image != null) {
+                    return image;
+                }
+            }
+        }
+
+        URL svgUrl = LinerGuides.class.getResource("/liner.svg");
+        if (svgUrl == null) {
+            throw new IOException("liner.svg resource is missing");
+        }
+
+        SvgHandle handle = SvgLoader.load(svgUrl.toString());
+        int width = (int) Math.ceil(handle.getBounds().getWidth());
+        int height = (int) Math.ceil(handle.getBounds().getHeight());
+        if (width <= 0 || height <= 0) {
+            throw new IOException("liner.svg has invalid dimensions");
+        }
+
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = image.createGraphics();
+        try {
+            g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g2d.setColor(Color.WHITE);
+            g2d.fillRect(0, 0, width, height);
+            g2d.translate(-handle.getBounds().getX(), -handle.getBounds().getY());
+            handle.getGraphicsNode().paint(g2d);
+        } finally {
+            g2d.dispose();
+        }
+        return image;
+    }
+
+    private static List<BodyStripe> parseBodyStripes() throws IOException {
+        List<Double> yPositions = new ArrayList<>();
+        try (InputStream svgStream = LinerGuides.class.getResourceAsStream("/liner.svg")) {
+            if (svgStream == null) {
+                return Collections.emptyList();
+            }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(svgStream, StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    Matcher matcher = HORIZONTAL_LINE_PATTERN.matcher(line);
+                    if (matcher.find()) {
+                        double y = Double.parseDouble(matcher.group(1));
+                        yPositions.add(y);
+                    }
+                }
+            }
+        }
+        Collections.sort(yPositions);
+        List<BodyStripe> stripes = new ArrayList<>();
+        List<Double> group = new ArrayList<>(4);
+        for (double y : yPositions) {
+            if (y < 100) {
+                continue;
+            }
+            group.add(y);
+            if (group.size() == 4) {
+                stripes.add(new BodyStripe(group.get(1), group.get(2)));
+                group.clear();
+            }
+        }
+        return Collections.unmodifiableList(stripes);
+    }
+
+    static final class BodyStripe {
+        private final double top;
+        private final double bottom;
+
+        BodyStripe(double top, double bottom) {
+            this.top = top;
+            this.bottom = bottom;
+        }
+
+        double getTop() {
+            return top;
+        }
+
+        double getBottom() {
+            return bottom;
+        }
+    }
+}

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/SceneEditorFrame.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/SceneEditorFrame.java
@@ -1,0 +1,301 @@
+package tatar.eljah.hamsters.tools.sceneeditor;
+
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.utils.JsonReader;
+import com.badlogic.gdx.utils.JsonValue;
+
+import javax.swing.DefaultListModel;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JList;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextField;
+import javax.swing.ListSelectionModel;
+import javax.swing.SwingConstants;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+class SceneEditorFrame extends JFrame {
+    private final SceneEditorPanel editorPanel;
+    private final DefaultListModel<BlockDefinition> blockListModel;
+    private final JList<BlockDefinition> blockList;
+    private final JTextField sceneNameField;
+    private final javax.swing.JLabel statusLabel;
+    private final LinerGuides linerGuides;
+    private final Map<String, BlockDefinition> definitionsByName = new HashMap<>();
+    private File currentSceneFile;
+
+    SceneEditorFrame() {
+        super("Scene Editor");
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+        try {
+            linerGuides = LinerGuides.load();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load liner assets", e);
+        }
+
+        statusLabel = new javax.swing.JLabel("Ready", SwingConstants.LEFT);
+
+        editorPanel = new SceneEditorPanel(linerGuides);
+        editorPanel.setSelectionListener(instance -> {
+            if (instance == null) {
+                statusLabel.setText("No block selected");
+            } else {
+                BlockDefinition definition = instance.getDefinition();
+                if (definition != null) {
+                    statusLabel.setText(String.format(Locale.US, "Selected %s at (%.1f, %.1f)",
+                            definition.getDisplayName(), instance.getX(), instance.getY()));
+                } else {
+                    statusLabel.setText("Selected block with missing definition");
+                }
+            }
+        });
+
+        JScrollPane scrollPane = new JScrollPane(editorPanel);
+        scrollPane.setPreferredSize(new Dimension(1024, 640));
+        add(scrollPane, BorderLayout.CENTER);
+
+        blockListModel = new DefaultListModel<>();
+        blockList = new JList<>(blockListModel);
+        blockList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        JScrollPane listScroll = new JScrollPane(blockList);
+        listScroll.setPreferredSize(new Dimension(200, 300));
+
+        JPanel leftPanel = new JPanel(new BorderLayout());
+        javax.swing.JLabel listLabel = new javax.swing.JLabel("Blocks", SwingConstants.CENTER);
+        leftPanel.add(listLabel, BorderLayout.NORTH);
+        leftPanel.add(listScroll, BorderLayout.CENTER);
+
+        JPanel leftButtons = new JPanel(new GridLayout(0, 1, 4, 4));
+        JButton addButton = new JButton("Add to Scene");
+        addButton.addActionListener(this::onAddBlock);
+        leftButtons.add(addButton);
+
+        JButton refreshButton = new JButton("Refresh Blocks");
+        refreshButton.addActionListener(e -> reloadBlockDefinitions());
+        leftButtons.add(refreshButton);
+
+        JButton removeButton = new JButton("Remove Selected");
+        removeButton.addActionListener(e -> {
+            if (editorPanel.removeSelectedInstance()) {
+                statusLabel.setText("Removed block from scene");
+            } else {
+                statusLabel.setText("Nothing to remove");
+            }
+        });
+        leftButtons.add(removeButton);
+
+        JButton clearButton = new JButton("Clear Scene");
+        clearButton.addActionListener(e -> {
+            editorPanel.clearScene();
+            statusLabel.setText("Scene cleared");
+        });
+        leftButtons.add(clearButton);
+
+        leftPanel.add(leftButtons, BorderLayout.SOUTH);
+        add(leftPanel, BorderLayout.WEST);
+
+        JPanel topPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        topPanel.add(new javax.swing.JLabel("Scene name:"));
+        sceneNameField = new JTextField("scene", 20);
+        topPanel.add(sceneNameField);
+
+        JButton loadButton = new JButton("Load Scene");
+        loadButton.addActionListener(this::onLoadScene);
+        topPanel.add(loadButton);
+
+        JButton saveButton = new JButton("Save Scene");
+        saveButton.addActionListener(this::onSaveScene);
+        topPanel.add(saveButton);
+
+        add(topPanel, BorderLayout.NORTH);
+
+        add(statusLabel, BorderLayout.SOUTH);
+
+        pack();
+        setLocationRelativeTo(null);
+
+        reloadBlockDefinitions();
+    }
+
+    private void onAddBlock(ActionEvent event) {
+        BlockDefinition selected = blockList.getSelectedValue();
+        if (selected == null) {
+            statusLabel.setText("Select a block to add");
+            return;
+        }
+        editorPanel.addBlock(selected);
+        statusLabel.setText("Added block " + selected.getDisplayName());
+    }
+
+    private void onSaveScene(ActionEvent event) {
+        List<BlockInstance> instances = editorPanel.getInstances();
+        if (instances.isEmpty()) {
+            int result = JOptionPane.showConfirmDialog(this, "Scene is empty. Save anyway?", "Confirm",
+                    JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+            if (result != JOptionPane.YES_OPTION) {
+                return;
+            }
+        }
+        String sceneName = sceneNameField.getText().trim();
+        if (sceneName.isEmpty()) {
+            JOptionPane.showMessageDialog(this, "Enter scene name", "Warning", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+        if (!sceneName.endsWith(".json")) {
+            sceneName = sceneName + ".json";
+        }
+        Path targetDir = Paths.get("assets", "scenes");
+        try {
+            Files.createDirectories(targetDir);
+            Path target = targetDir.resolve(sceneName);
+            String json = buildSceneJson(instances);
+            Files.write(target, json.getBytes(StandardCharsets.UTF_8));
+            currentSceneFile = target.toFile();
+            statusLabel.setText("Scene saved to " + target.toAbsolutePath());
+        } catch (IOException e) {
+            JOptionPane.showMessageDialog(this, "Failed to save scene: " + e.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void onLoadScene(ActionEvent event) {
+        JFileChooser chooser = new JFileChooser();
+        chooser.setFileFilter(new FileNameExtensionFilter("Scene JSON", "json"));
+        Path scenesDir = Paths.get("assets", "scenes");
+        if (Files.isDirectory(scenesDir)) {
+            chooser.setCurrentDirectory(scenesDir.toFile());
+        }
+        if (currentSceneFile != null) {
+            chooser.setSelectedFile(currentSceneFile);
+        }
+        if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+            File file = chooser.getSelectedFile();
+            try {
+                loadScene(file);
+                currentSceneFile = file;
+                sceneNameField.setText(stripExtension(file.getName()));
+                statusLabel.setText("Loaded scene " + file.getName());
+            } catch (IOException ex) {
+                JOptionPane.showMessageDialog(this, "Failed to load scene: " + ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private void loadScene(File file) throws IOException {
+        JsonReader reader = new JsonReader();
+        JsonValue root = reader.parse(new FileHandle(file));
+        JsonValue blocks = root.get("blocks");
+        editorPanel.clearScene();
+        if (blocks == null || !blocks.isArray()) {
+            return;
+        }
+        for (JsonValue item : blocks) {
+            String blockName = item.getString("block");
+            BlockDefinition definition = definitionsByName.get(blockName);
+            if (definition == null) {
+                JOptionPane.showMessageDialog(this,
+                        "Block " + blockName + " is missing. Skipping.",
+                        "Warning",
+                        JOptionPane.WARNING_MESSAGE);
+                continue;
+            }
+            double x = item.getDouble("x", 0.0);
+            double y = item.getDouble("y", 0.0);
+            editorPanel.addBlock(definition, x, y, false);
+        }
+        statusLabel.setText(String.format(Locale.US, "Loaded %d blocks", editorPanel.getInstances().size()));
+    }
+
+    private String buildSceneJson(List<BlockInstance> instances) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        sb.append(String.format(Locale.US, "  \"background\": \"%s\",\n", linerGuides.getBackgroundAssetName()));
+        sb.append(String.format(Locale.US, "  \"canvasWidth\": %d,\n", editorPanel.getCanvasWidth()));
+        sb.append(String.format(Locale.US, "  \"canvasHeight\": %d,\n", editorPanel.getCanvasHeight()));
+        if (instances.isEmpty()) {
+            sb.append("  \"blocks\": []\n");
+        } else {
+            sb.append("  \"blocks\": [\n");
+            for (int i = 0; i < instances.size(); i++) {
+                BlockInstance instance = instances.get(i);
+                sb.append(String.format(Locale.US,
+                        "    {\"block\": \"%s\", \"x\": %.3f, \"y\": %.3f}",
+                        instance.getBlockReference(),
+                        instance.getX(),
+                        instance.getY()));
+                if (i < instances.size() - 1) {
+                    sb.append(',');
+                }
+                sb.append('\n');
+            }
+            sb.append("  ]\n");
+        }
+        sb.append("}\n");
+        return sb.toString();
+    }
+
+    private void reloadBlockDefinitions() {
+        Path blocksDir = Paths.get("assets", "blocks");
+        List<BlockDefinition> loaded = new ArrayList<>();
+        definitionsByName.clear();
+        if (Files.isDirectory(blocksDir)) {
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(blocksDir, "*.json")) {
+                for (Path json : stream) {
+                    try {
+                        BlockDefinition definition = BlockDefinition.load(json.toFile());
+                        loaded.add(definition);
+                        definitionsByName.put(definition.getJsonFileName(), definition);
+                    } catch (IOException e) {
+                        JOptionPane.showMessageDialog(this,
+                                "Failed to load block " + json.getFileName() + ": " + e.getMessage(),
+                                "Error",
+                                JOptionPane.ERROR_MESSAGE);
+                    }
+                }
+            } catch (IOException e) {
+                JOptionPane.showMessageDialog(this, "Failed to read blocks directory: " + e.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+        loaded.sort(Comparator.comparing(BlockDefinition::getDisplayName, String.CASE_INSENSITIVE_ORDER));
+        blockListModel.clear();
+        for (BlockDefinition definition : loaded) {
+            blockListModel.addElement(definition);
+        }
+        if (!loaded.isEmpty()) {
+            blockList.setSelectedIndex(0);
+            statusLabel.setText(String.format(Locale.US, "Loaded %d blocks", loaded.size()));
+        } else {
+            statusLabel.setText("No blocks found in assets/blocks");
+        }
+        editorPanel.remapDefinitions(definitionsByName);
+    }
+
+    private static String stripExtension(String name) {
+        int idx = name.lastIndexOf('.');
+        if (idx > 0) {
+            return name.substring(0, idx);
+        }
+        return name;
+    }
+}

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/SceneEditorLauncher.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/SceneEditorLauncher.java
@@ -1,0 +1,15 @@
+package tatar.eljah.hamsters.tools.sceneeditor;
+
+import javax.swing.SwingUtilities;
+
+public final class SceneEditorLauncher {
+    private SceneEditorLauncher() {
+    }
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            SceneEditorFrame frame = new SceneEditorFrame();
+            frame.setVisible(true);
+        });
+    }
+}

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/SceneEditorPanel.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/SceneEditorPanel.java
@@ -1,0 +1,327 @@
+package tatar.eljah.hamsters.tools.sceneeditor;
+
+import javax.swing.AbstractAction;
+import javax.swing.JPanel;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.RenderingHints;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+final class SceneEditorPanel extends JPanel {
+    private static final Color SELECTION_COLOR = new Color(0, 120, 215, 140);
+    private static final Color BODY_FILL = new Color(204, 0, 0, 80);
+    private static final Color BODY_BORDER = new Color(204, 0, 0);
+    private static final Color ASC_FILL = new Color(0, 128, 0, 60);
+    private static final Color ASC_BORDER = new Color(0, 128, 0);
+    private static final Color DESC_FILL = new Color(0, 0, 204, 60);
+    private static final Color DESC_BORDER = new Color(0, 0, 204);
+
+    private final BufferedImage backgroundImage;
+    private final List<LinerGuides.BodyStripe> bodyStripes;
+    private final List<BlockInstance> instances = new ArrayList<>();
+
+    private BlockInstance selectedInstance;
+    private Point dragStart;
+    private double initialX;
+    private double initialY;
+    private Consumer<BlockInstance> selectionListener;
+
+    SceneEditorPanel(LinerGuides guides) {
+        this.backgroundImage = guides.getBackgroundImage();
+        this.bodyStripes = guides.getBodyStripes();
+        setBackground(Color.WHITE);
+        setPreferredSize(new Dimension(backgroundImage.getWidth(), backgroundImage.getHeight()));
+        setFocusable(true);
+
+        MouseHandler handler = new MouseHandler();
+        addMouseListener(handler);
+        addMouseMotionListener(handler);
+
+        getInputMap(WHEN_FOCUSED).put(KeyStroke.getKeyStroke("DELETE"), "deleteBlock");
+        getActionMap().put("deleteBlock", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                removeSelectedInstance();
+            }
+        });
+    }
+
+    void setSelectionListener(Consumer<BlockInstance> listener) {
+        this.selectionListener = listener;
+    }
+
+    BlockInstance addBlock(BlockDefinition definition) {
+        double x = computeDefaultX(definition);
+        double y = computeDefaultY(definition);
+        return addBlock(definition, x, y, true);
+    }
+
+    BlockInstance addBlock(BlockDefinition definition, double x, double y, boolean select) {
+        double clampedY = clampY(definition, y);
+        BlockInstance instance = new BlockInstance(definition, x, clampedY);
+        instances.add(instance);
+        if (select) {
+            selectedInstance = instance;
+            notifySelectionChanged();
+        }
+        repaint();
+        return instance;
+    }
+
+    boolean removeSelectedInstance() {
+        if (selectedInstance == null) {
+            return false;
+        }
+        boolean removed = instances.remove(selectedInstance);
+        if (removed) {
+            selectedInstance = null;
+            repaint();
+            notifySelectionChanged();
+        }
+        return removed;
+    }
+
+    void clearScene() {
+        instances.clear();
+        selectedInstance = null;
+        repaint();
+        notifySelectionChanged();
+    }
+
+    List<BlockInstance> getInstances() {
+        return Collections.unmodifiableList(instances);
+    }
+
+    BlockInstance getSelectedInstance() {
+        return selectedInstance;
+    }
+
+    void remapDefinitions(Map<String, BlockDefinition> definitions) {
+        boolean changed = false;
+        for (BlockInstance instance : instances) {
+            BlockDefinition updated = definitions.get(instance.getBlockReference());
+            if (updated != null && updated != instance.getDefinition()) {
+                instance.setDefinition(updated);
+                instance.setY(clampY(updated, instance.getY()));
+                changed = true;
+            }
+        }
+        if (changed) {
+            repaint();
+        }
+    }
+
+    int getCanvasWidth() {
+        return backgroundImage.getWidth();
+    }
+
+    int getCanvasHeight() {
+        return backgroundImage.getHeight();
+    }
+
+    double clampY(BlockDefinition definition, double desiredY) {
+        if (definition == null) {
+            return desiredY;
+        }
+        Rectangle2D.Double body = definition.getBodyRect();
+        if (body == null || bodyStripes.isEmpty()) {
+            return desiredY;
+        }
+        double epsilon = 1e-6;
+        for (LinerGuides.BodyStripe stripe : bodyStripes) {
+            double minY = stripe.getTop() - body.y;
+            double maxY = stripe.getBottom() - (body.y + body.height);
+            if (minY > maxY) {
+                continue;
+            }
+            if (desiredY >= minY - epsilon && desiredY <= maxY + epsilon) {
+                return Math.max(minY, Math.min(desiredY, maxY));
+            }
+        }
+        double bestY = desiredY;
+        double closestDistance = Double.POSITIVE_INFINITY;
+        for (LinerGuides.BodyStripe stripe : bodyStripes) {
+            double minY = stripe.getTop() - body.y;
+            double maxY = stripe.getBottom() - (body.y + body.height);
+            if (minY > maxY) {
+                continue;
+            }
+            double clamped = Math.max(minY, Math.min(desiredY, maxY));
+            double distance = Math.abs(desiredY - clamped);
+            if (distance < closestDistance) {
+                closestDistance = distance;
+                bestY = clamped;
+            }
+        }
+        return bestY;
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        Graphics2D g2d = (Graphics2D) g.create();
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g2d.drawImage(backgroundImage, 0, 0, null);
+
+        for (BlockInstance instance : instances) {
+            BlockDefinition definition = instance.getDefinition();
+            if (definition == null) {
+                continue;
+            }
+            Graphics2D blockGraphics = (Graphics2D) g2d.create();
+            blockGraphics.translate(instance.getX(), instance.getY());
+            drawBlock(blockGraphics, definition);
+            blockGraphics.dispose();
+
+            if (instance == selectedInstance) {
+                drawSelectionOverlays(g2d, instance, definition);
+            }
+        }
+
+        g2d.dispose();
+    }
+
+    private void drawBlock(Graphics2D g2d, BlockDefinition definition) {
+        Graphics2D svgGraphics = (Graphics2D) g2d.create();
+        svgGraphics.translate(definition.getSvgDrawX(), definition.getSvgY());
+        svgGraphics.scale(definition.getSvgScale(), definition.getSvgScale());
+        Rectangle2D svgBounds = definition.getSvgBounds();
+        svgGraphics.translate(-svgBounds.getX(), -svgBounds.getY());
+        definition.getSvgHandle().getGraphicsNode().paint(svgGraphics);
+        svgGraphics.dispose();
+    }
+
+    private void drawSelectionOverlays(Graphics2D g2d, BlockInstance instance, BlockDefinition definition) {
+        Rectangle2D.Double bounds = instance.getBoundingBox();
+        Graphics2D outline = (Graphics2D) g2d.create();
+        outline.setColor(SELECTION_COLOR);
+        outline.setStroke(new BasicStroke(1.8f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1f, new float[]{6f, 6f}, 0f));
+        outline.draw(bounds);
+        outline.dispose();
+
+        Graphics2D overlay = (Graphics2D) g2d.create();
+        overlay.setStroke(new BasicStroke(1.4f));
+        Rectangle2D.Double body = definition.getBodyRect();
+        if (body != null) {
+            Rectangle2D.Double bodyRect = new Rectangle2D.Double(body.x + instance.getX(), body.y + instance.getY(), body.width, body.height);
+            overlay.setColor(BODY_FILL);
+            overlay.fill(bodyRect);
+            overlay.setColor(BODY_BORDER);
+            overlay.draw(bodyRect);
+        }
+        overlay.setColor(ASC_BORDER);
+        for (Rectangle2D.Double asc : definition.getAscenders()) {
+            Rectangle2D.Double rect = new Rectangle2D.Double(asc.x + instance.getX(), asc.y + instance.getY(), asc.width, asc.height);
+            overlay.setColor(ASC_FILL);
+            overlay.fill(rect);
+            overlay.setColor(ASC_BORDER);
+            overlay.draw(rect);
+        }
+        overlay.setColor(DESC_BORDER);
+        for (Rectangle2D.Double desc : definition.getDescenders()) {
+            Rectangle2D.Double rect = new Rectangle2D.Double(desc.x + instance.getX(), desc.y + instance.getY(), desc.width, desc.height);
+            overlay.setColor(DESC_FILL);
+            overlay.fill(rect);
+            overlay.setColor(DESC_BORDER);
+            overlay.draw(rect);
+        }
+        overlay.dispose();
+    }
+
+    private double computeDefaultX(BlockDefinition definition) {
+        Rectangle2D.Double bounds = definition.getContentBounds();
+        double margin = 24.0;
+        double availableWidth = getCanvasWidth() - bounds.width - margin;
+        double proposal = margin + instances.size() * 40.0;
+        if (availableWidth <= margin) {
+            return margin;
+        }
+        return Math.max(margin, Math.min(proposal, availableWidth));
+    }
+
+    private double computeDefaultY(BlockDefinition definition) {
+        Rectangle2D.Double body = definition.getBodyRect();
+        if (body == null || bodyStripes.isEmpty()) {
+            return 0.0;
+        }
+        double top = bodyStripes.get(0).getTop();
+        double desired = top - body.y;
+        return clampY(definition, desired);
+    }
+
+    private BlockInstance findInstanceAt(Point point) {
+        for (int i = instances.size() - 1; i >= 0; i--) {
+            BlockInstance instance = instances.get(i);
+            Rectangle2D.Double bounds = instance.getBoundingBox();
+            if (bounds.contains(point)) {
+                return instance;
+            }
+        }
+        return null;
+    }
+
+    private void notifySelectionChanged() {
+        if (selectionListener != null) {
+            selectionListener.accept(selectedInstance);
+        }
+    }
+
+    private final class MouseHandler extends MouseAdapter {
+        @Override
+        public void mousePressed(MouseEvent e) {
+            requestFocusInWindow();
+            if (!SwingUtilities.isLeftMouseButton(e)) {
+                return;
+            }
+            Point point = e.getPoint();
+            BlockInstance found = findInstanceAt(point);
+            if (found != null) {
+                selectedInstance = found;
+                dragStart = point;
+                initialX = found.getX();
+                initialY = found.getY();
+                instances.remove(found);
+                instances.add(found);
+                repaint();
+                notifySelectionChanged();
+            } else if (selectedInstance != null) {
+                selectedInstance = null;
+                repaint();
+                notifySelectionChanged();
+            }
+        }
+
+        @Override
+        public void mouseDragged(MouseEvent e) {
+            if (!SwingUtilities.isLeftMouseButton(e) || selectedInstance == null || dragStart == null) {
+                return;
+            }
+            double dx = e.getX() - dragStart.x;
+            double dy = e.getY() - dragStart.y;
+            double newX = initialX + dx;
+            double newY = clampY(selectedInstance.getDefinition(), initialY + dy);
+            selectedInstance.setPosition(newX, newY);
+            repaint();
+        }
+
+        @Override
+        public void mouseReleased(MouseEvent e) {
+            dragStart = null;
+        }
+    }
+}

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/svg/SvgHandle.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/svg/SvgHandle.java
@@ -1,23 +1,23 @@
-package tatar.eljah.hamsters.tools.blockeditor;
+package tatar.eljah.hamsters.tools.svg;
 
 import org.apache.batik.gvt.GraphicsNode;
 
 import java.awt.geom.Rectangle2D;
 
-final class SvgHandle {
+public final class SvgHandle {
     private final GraphicsNode graphicsNode;
     private final Rectangle2D bounds;
 
-    SvgHandle(GraphicsNode graphicsNode, Rectangle2D bounds) {
+    public SvgHandle(GraphicsNode graphicsNode, Rectangle2D bounds) {
         this.graphicsNode = graphicsNode;
         this.bounds = bounds;
     }
 
-    GraphicsNode getGraphicsNode() {
+    public GraphicsNode getGraphicsNode() {
         return graphicsNode;
     }
 
-    Rectangle2D getBounds() {
+    public Rectangle2D getBounds() {
         return bounds;
     }
 }

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/svg/SvgLoader.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/svg/SvgLoader.java
@@ -1,4 +1,4 @@
-package tatar.eljah.hamsters.tools.blockeditor;
+package tatar.eljah.hamsters.tools.svg;
 
 import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
 import org.apache.batik.bridge.BridgeContext;
@@ -13,15 +13,15 @@ import java.awt.geom.Rectangle2D;
 import java.io.File;
 import java.io.IOException;
 
-final class SvgLoader {
+public final class SvgLoader {
     private SvgLoader() {
     }
 
-    static SvgHandle load(File file) throws IOException {
+    public static SvgHandle load(File file) throws IOException {
         return load(file.toURI().toString());
     }
 
-    static SvgHandle load(String uri) throws IOException {
+    public static SvgHandle load(String uri) throws IOException {
         String parser = XMLResourceDescriptor.getXMLParserClassName();
         SAXSVGDocumentFactory factory = new SAXSVGDocumentFactory(parser);
         SVGDocument document = factory.createSVGDocument(uri);


### PR DESCRIPTION
## Summary
- add a Swing-based scene editor that loads annotated blocks and saves composed scenes as JSON referencing those blocks
- enforce liner placement rules so block bodies stay between guide lines while ascenders and descenders may overflow, and allow scene load/save/edit flows
- extract shared SVG loading utilities and update the Gradle launcher configuration to support the new editor

## Testing
- `./gradlew :tools:compileJava --quiet --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68df779ce81c832a902d4336724114a0