### PR TITLE
Add controls to move selected block between guide lines

### DIFF
--- a/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/BlockEditorFrame.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/blockeditor/BlockEditorFrame.java
@@ -77,6 +77,14 @@ public class BlockEditorFrame extends JFrame {
         remove.addActionListener(e -> statusLabel.setText(editorPanel.removeSelectedRegion()));
         controls.add(remove);
 
+        JButton moveUp = new JButton("Move Up");
+        moveUp.addActionListener(e -> statusLabel.setText(editorPanel.moveSelectedRegionUpOneLine()));
+        controls.add(moveUp);
+
+        JButton moveDown = new JButton("Move Down");
+        moveDown.addActionListener(e -> statusLabel.setText(editorPanel.moveSelectedRegionDownOneLine()));
+        controls.add(moveDown);
+
         JButton save = new JButton("Save");
         save.addActionListener(this::onSave);
         controls.add(save);


### PR DESCRIPTION
## Summary
- detect guide line positions from the liner background so blocks can snap vertically
- add reusable helpers to move the selected block one line up or down while clamping to the canvas
- expose new Move Up/Move Down buttons in the block editor toolbar for quick lane changes

## Testing
- ./gradlew :tools:compileJava --console=plain -i

------
https://chatgpt.com/codex/tasks/task_e_68df856b8564832ab1989b7943628193