### PR TITLE
Add controls to move scene editor blocks between stripes

### DIFF
--- a/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/SceneEditorFrame.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/SceneEditorFrame.java
@@ -106,6 +106,38 @@ class SceneEditorFrame extends JFrame {
         });
         leftButtons.add(removeButton);
 
+        JButton moveUpButton = new JButton("Move Up");
+        moveUpButton.addActionListener(e -> {
+            if (editorPanel.moveSelectedInstanceUp()) {
+                BlockInstance selected = editorPanel.getSelectedInstance();
+                if (selected != null && selected.getDefinition() != null) {
+                    statusLabel.setText(String.format(Locale.US, "Moved %s to (%.1f, %.1f)",
+                            selected.getDefinition().getDisplayName(), selected.getX(), selected.getY()));
+                } else {
+                    statusLabel.setText("Moved block up");
+                }
+            } else {
+                statusLabel.setText("Cannot move block up");
+            }
+        });
+        leftButtons.add(moveUpButton);
+
+        JButton moveDownButton = new JButton("Move Down");
+        moveDownButton.addActionListener(e -> {
+            if (editorPanel.moveSelectedInstanceDown()) {
+                BlockInstance selected = editorPanel.getSelectedInstance();
+                if (selected != null && selected.getDefinition() != null) {
+                    statusLabel.setText(String.format(Locale.US, "Moved %s to (%.1f, %.1f)",
+                            selected.getDefinition().getDisplayName(), selected.getX(), selected.getY()));
+                } else {
+                    statusLabel.setText("Moved block down");
+                }
+            } else {
+                statusLabel.setText("Cannot move block down");
+            }
+        });
+        leftButtons.add(moveDownButton);
+
         JButton clearButton = new JButton("Clear Scene");
         clearButton.addActionListener(e -> {
             editorPanel.clearScene();

--- a/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/SceneEditorPanel.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/SceneEditorPanel.java
@@ -119,6 +119,14 @@ final class SceneEditorPanel extends JPanel {
         return selectedInstance;
     }
 
+    boolean moveSelectedInstanceUp() {
+        return moveSelectedInstance(-1);
+    }
+
+    boolean moveSelectedInstanceDown() {
+        return moveSelectedInstance(1);
+    }
+
     void remapDefinitions(Map<String, BlockDefinition> definitions) {
         boolean changed = false;
         for (BlockInstance instance : instances) {
@@ -180,6 +188,36 @@ final class SceneEditorPanel extends JPanel {
             }
         }
         return bestY;
+    }
+
+    private boolean moveSelectedInstance(int deltaStripe) {
+        if (selectedInstance == null) {
+            return false;
+        }
+        BlockDefinition definition = selectedInstance.getDefinition();
+        if (definition == null) {
+            return false;
+        }
+        if (currentStripePlacements.isEmpty()) {
+            updateStripeContext(selectedInstance);
+        }
+        if (currentStripePlacements.isEmpty()) {
+            return false;
+        }
+        int currentIndex = activeStripeIndex;
+        if (currentIndex < 0) {
+            currentIndex = findStripeIndex(currentStripePlacements, selectedInstance.getY());
+        }
+        int targetIndex = currentIndex + deltaStripe;
+        if (targetIndex < 0 || targetIndex >= currentStripePlacements.size()) {
+            return false;
+        }
+        StripePlacement placement = currentStripePlacements.get(targetIndex);
+        selectedInstance.setY(placement.snapY);
+        activeStripeIndex = targetIndex;
+        repaint();
+        notifySelectionChanged();
+        return true;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add move up/down buttons to the scene editor UI for rearranging the selected block
- expose helper methods that shift the selected block between liner stripes with snapping

## Testing
- not run (tool-only change)


------
https://chatgpt.com/codex/tasks/task_e_68df89a05810832abc2abc6fed3a0f5c