### PR TITLE
Fix Scene Editor body stripe alignment

### DIFF
--- a/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/LinerGuides.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/LinerGuides.java
@@ -113,7 +113,7 @@ final class LinerGuides {
             }
             group.add(y);
             if (group.size() == 4) {
-                stripes.add(new BodyStripe(group.get(1), group.get(2)));
+                stripes.add(new BodyStripe(group.get(0), group.get(1)));
                 group.clear();
             }
         }


### PR DESCRIPTION
## Summary
- align body snapping stripes with the first pair of guide lines in liner.svg so Scene Editor placement matches orange markers

## Testing
- not run (dependency download stalled when running `./gradlew :tools:check`)


------
https://chatgpt.com/codex/tasks/task_e_68df9d4ce874832ab75186e905bc1fb7