### PR TITLE
Handle overlapping liner guide stripes

### DIFF
--- a/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/LinerGuides.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/LinerGuides.java
@@ -114,7 +114,9 @@ final class LinerGuides {
             group.add(y);
             if (group.size() == 4) {
                 stripes.add(new BodyStripe(group.get(1), group.get(2)));
+                double carry = group.get(3);
                 group.clear();
+                group.add(carry);
             }
         }
         return Collections.unmodifiableList(stripes);


### PR DESCRIPTION
## Summary
- keep the fourth guide line of each liner group as the start of the next group when computing body stripes
- restore body stripe bounds to the second and third guide lines so snapping matches the orange markers

## Testing
- not run (gradle dependency download stalled and command was interrupted)


------
https://chatgpt.com/codex/tasks/task_e_68df9d4ce874832ab75186e905bc1fb7