### PR TITLE
Shift liner body stripes up one line

### DIFF
--- a/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/LinerGuides.java
+++ b/tools/src/main/java/tatar/eljah/hamsters/tools/sceneeditor/LinerGuides.java
@@ -113,8 +113,10 @@ final class LinerGuides {
             }
             group.add(y);
             if (group.size() == 4) {
-                stripes.add(new BodyStripe(group.get(1), group.get(2)));
+                stripes.add(new BodyStripe(group.get(0), group.get(1)));
+                double carry = group.get(3);
                 group.clear();
+                group.add(carry);
             }
         }
         return Collections.unmodifiableList(stripes);


### PR DESCRIPTION
## Summary
- move body stripe bounds to the first two lines of each liner guide quartet so the snap area shifts up one line

## Testing
- ./gradlew :tools:check --console=plain *(interrupted after hanging before task execution)*

------
https://chatgpt.com/codex/tasks/task_e_68df9d4ce874832ab75186e905bc1fb7