### PR TITLE
Load scene from configuration and enforce block collisions

### DIFF
--- a/core/src/main/java/tatar/eljah/hamsters/Block.java
+++ b/core/src/main/java/tatar/eljah/hamsters/Block.java
@@ -1,29 +1,30 @@
 package tatar.eljah.hamsters;
 
 import com.badlogic.gdx.math.Rectangle;
+import com.badlogic.gdx.utils.Array;
 
 /**
- * Represents an obstacle on the line paper. A block may have three parts:
- * ascender (above the line), body (between lines) and descender (below the line).
- * Only the body is solid for collision purposes. Ascender and descender regions
- * are passable for the hamster.
+ * Represents an obstacle on the lined paper. A block may have three kinds of
+ * solid regions: the body (between the lines), optional ascenders (above the
+ * line) and optional descenders (below the line). All regions are solid for
+ * collision purposes and characters may only touch them.
  */
 public class Block {
     /** Solid part between the lines. */
     public final Rectangle body;
-    /** Optional area above the top line. Hamster can pass through. */
-    public final Rectangle ascender;
-    /** Optional area below the bottom line. Hamster can pass through. */
-    public final Rectangle descender;
+    /** Optional solid areas above the line. */
+    public final Array<Rectangle> ascenders;
+    /** Optional solid areas below the line. */
+    public final Array<Rectangle> descenders;
 
     public Block(Rectangle body) {
         this(body, null, null);
     }
 
-    public Block(Rectangle body, Rectangle ascender, Rectangle descender) {
+    public Block(Rectangle body, Array<Rectangle> ascenders, Array<Rectangle> descenders) {
         this.body = body;
-        this.ascender = ascender;
-        this.descender = descender;
+        this.ascenders = ascenders != null ? ascenders : new Array<>();
+        this.descenders = descenders != null ? descenders : new Array<>();
     }
 }
 

--- a/core/src/main/java/tatar/eljah/hamsters/Block.java
+++ b/core/src/main/java/tatar/eljah/hamsters/Block.java
@@ -1,5 +1,6 @@
 package tatar.eljah.hamsters;
 
+import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.utils.Array;
 
@@ -17,14 +18,25 @@ public class Block {
     /** Optional solid areas below the line. */
     public final Array<Rectangle> descenders;
 
+    /** Rendering bounds for the block's SVG texture. */
+    public final Rectangle drawBounds;
+    /** Texture that should be rendered for this block. */
+    public final Texture texture;
+
     public Block(Rectangle body) {
-        this(body, null, null);
+        this(body, null, null, null, null);
     }
 
-    public Block(Rectangle body, Array<Rectangle> ascenders, Array<Rectangle> descenders) {
+    public Block(Rectangle body,
+                 Array<Rectangle> ascenders,
+                 Array<Rectangle> descenders,
+                 Rectangle drawBounds,
+                 Texture texture) {
         this.body = body;
         this.ascenders = ascenders != null ? ascenders : new Array<>();
         this.descenders = descenders != null ? descenders : new Array<>();
+        this.drawBounds = drawBounds;
+        this.texture = texture;
     }
 }
 


### PR DESCRIPTION
## Summary
- load the scene definition from `scene.json`, including background dimensions and block placements, and build reusable block templates
- update the block model to track ascender and descender pieces and reuse them across resets while seeding the grid from the configured layout
- adjust collision handling and rendering bounds to respect the configured scene size and treat every block piece as solid

## Testing
- ./gradlew :core:compileJava

------
https://chatgpt.com/codex/tasks/task_e_68dfabef2ed4832ab2bdefcaeb5b887c