### PR TITLE
Ensure Android build picks up scene configuration assets

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -99,6 +99,11 @@ tasks.matching { it.name.contains("merge") && it.name.contains("JniLibFolders") 
   packageTask.dependsOn 'copyAndroidNatives'
 }
 
+def assetListTask = project(':core').tasks.named('generateAssetList')
+tasks.matching { it.name.startsWith('merge') && it.name.endsWith('Assets') }.configureEach { mergeTask ->
+  mergeTask.dependsOn(assetListTask)
+}
+
 tasks.register('run', Exec) {
   def path
   def localProperties = project.file("../local.properties")

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ configure(subprojects - project(':android')) {
     File assetsFolder = new File("${project.rootDir}/assets/")
     // projectFolder/assets/assets.txt
     File assetsFile = new File(assetsFolder, "assets.txt")
+    outputs.file(assetsFile)
     // delete that file in case we've already created it
     assetsFile.delete()
 

--- a/core/src/main/java/tatar/eljah/hamsters/Main.java
+++ b/core/src/main/java/tatar/eljah/hamsters/Main.java
@@ -84,7 +84,10 @@ public class Main extends ApplicationAdapter {
         try {
             sceneJson = new JsonReader().parse(Gdx.files.internal("scenes/scene.json"));
         } catch (Exception e) {
-            Gdx.app.error("Main", "Failed to load scene configuration", e);
+            Gdx.app.error("Main", "Failed to load scene configuration from scenes/scene.json", e);
+        }
+        if (sceneJson == null) {
+            Gdx.app.log("Main", "Scene configuration unavailable; falling back to default layout");
         }
         if (sceneJson != null) {
             sceneWidth = sceneJson.getInt("canvasWidth", sceneWidth);


### PR DESCRIPTION
## Summary
- declare the generated assets.txt file as an output so Gradle knows when to refresh it
- make Android asset merge tasks depend on the shared assets list generation so new scene configs ship with APKs
- add clearer logging when the scene configuration file cannot be loaded and the legacy layout is used

## Testing
- ./gradlew core:generateAssetList

------
https://chatgpt.com/codex/tasks/task_e_68dfc77f0d74832a87eab63310fb3c07