### PR TITLE
Fix Gradle asset list dependency configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,25 +34,35 @@ configure(subprojects - project(':android')) {
 
   // From https://lyze.dev/2021/04/29/libGDX-Internal-Assets-List/
   // The article can be helpful when using assets.txt in your project.
-  tasks.register('generateAssetList') {
-    inputs.dir("${project.rootDir}/assets/")
-    // projectFolder/assets
-    File assetsFolder = new File("${project.rootDir}/assets/")
-    // projectFolder/assets/assets.txt
-    File assetsFile = new File(assetsFolder, "assets.txt")
-    outputs.file(assetsFile)
-    // delete that file in case we've already created it
-    assetsFile.delete()
+  def assetListTask
+  if (project == project(':core')) {
+    assetListTask = tasks.register('generateAssetList') {
+      inputs.dir("${project.rootDir}/assets/")
+      // projectFolder/assets
+      File assetsFolder = new File("${project.rootDir}/assets/")
+      // projectFolder/assets/assets.txt
+      File assetsFile = new File(assetsFolder, "assets.txt")
+      outputs.file(assetsFile)
+      // delete that file in case we've already created it
+      assetsFile.delete()
 
-    // iterate through all files inside that folder
-    // convert it to a relative path
-    // and append it to the file assets.txt
-    fileTree(assetsFolder)
-      .collect { assetsFolder.relativePath(it) }
-      .sort()
-      .each { assetsFile.append(it + "\n") }
+      // iterate through all files inside that folder
+      // convert it to a relative path
+      // and append it to the file assets.txt
+      fileTree(assetsFolder)
+        .collect { assetsFolder.relativePath(it) }
+        .sort()
+        .each { assetsFile.append(it + "\n") }
+    }
+  } else {
+    assetListTask = tasks.register('generateAssetList') {
+      dependsOn project(':core').tasks.named('generateAssetList')
+    }
   }
-  processResources.dependsOn 'generateAssetList'
+
+  tasks.named('processResources') {
+    dependsOn assetListTask
+  }
 
   compileJava {
     options.incremental = true


### PR DESCRIPTION
## Summary
- ensure only the core project generates the shared assets.txt file
- wire other modules' processResources tasks to depend on the core asset list generation

## Testing
- ./gradlew :lwjgl3:processResources --console=plain --dry-run --offline

------
https://chatgpt.com/codex/tasks/task_e_68dfd1a9662c832a872ba93eab16bda9