### PR TITLE
Document headless steps for scene transition logging

### DIFF
--- a/core/src/test/java/tatar/eljah/hamsters/MainSceneTransitionTest.java
+++ b/core/src/test/java/tatar/eljah/hamsters/MainSceneTransitionTest.java
@@ -1,0 +1,251 @@
+package tatar.eljah.hamsters;
+
+import static org.junit.Assert.assertTrue;
+
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.ApplicationLogger;
+import com.badlogic.gdx.ApplicationListener;
+import com.badlogic.gdx.Audio;
+import com.badlogic.gdx.Files;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.Net;
+import com.badlogic.gdx.Preferences;
+import com.badlogic.gdx.utils.Clipboard;
+import com.badlogic.gdx.LifecycleListener;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Ensures scene transition logging covers both gameplay and game over screens for each platform.
+ */
+public class MainSceneTransitionTest {
+
+    private Application previousApp;
+
+    @Before
+    public void stashApp() {
+        previousApp = Gdx.app;
+    }
+
+    @After
+    public void restoreApp() {
+        Gdx.app = previousApp;
+    }
+
+    @Test
+    public void logsGameplayAndGameOverScenesForAllPlatforms() throws Exception {
+        for (Application.ApplicationType type : new Application.ApplicationType[]{
+                Application.ApplicationType.Android,
+                Application.ApplicationType.Desktop
+        }) {
+            RecordingApplication app = new RecordingApplication(type);
+            Gdx.app = app;
+
+            Main main = new Main();
+            main.resetGameWithReason("unit test start");
+
+            Method triggerGameOver = Main.class.getDeclaredMethod("triggerGameOver", boolean.class, String.class);
+            triggerGameOver.setAccessible(true);
+            triggerGameOver.invoke(main, true, "unit test win");
+
+            List<String> logs = app.getLogs();
+
+            assertTrue("Scene 1 should be logged for " + type,
+                    logs.stream().anyMatch(message -> message.contains("Scene 1")));
+            assertTrue("Scene 2 should be logged for " + type,
+                    logs.stream().anyMatch(message -> message.contains("Scene 2")));
+            assertTrue("Platform name should be present in logs for " + type,
+                    logs.stream().anyMatch(message -> message.contains(type.name())));
+        }
+    }
+
+    private static final class RecordingApplication implements Application {
+        private final ApplicationType type;
+        private final List<String> logs = new ArrayList<>();
+        private final RecordingLogger logger = new RecordingLogger();
+        private int logLevel = LOG_INFO;
+
+        private RecordingApplication(ApplicationType type) {
+            this.type = type;
+        }
+
+        List<String> getLogs() {
+            return Collections.unmodifiableList(logs);
+        }
+
+        @Override
+        public ApplicationListener getApplicationListener() {
+            throw new UnsupportedOperationException("Not needed for the test");
+        }
+
+        @Override
+        public Graphics getGraphics() {
+            return null;
+        }
+
+        @Override
+        public Audio getAudio() {
+            return null;
+        }
+
+        @Override
+        public Input getInput() {
+            return null;
+        }
+
+        @Override
+        public Files getFiles() {
+            return null;
+        }
+
+        @Override
+        public Net getNet() {
+            return null;
+        }
+
+        @Override
+        public void log(String tag, String message) {
+            logs.add(tag + ": " + message);
+            logger.log(tag, message);
+        }
+
+        @Override
+        public void log(String tag, String message, Throwable exception) {
+            logs.add(tag + ": " + message + " (" + exception + ")");
+            logger.log(tag, message, exception);
+        }
+
+        @Override
+        public void error(String tag, String message) {
+            logs.add("ERROR " + tag + ": " + message);
+            logger.error(tag, message);
+        }
+
+        @Override
+        public void error(String tag, String message, Throwable exception) {
+            logs.add("ERROR " + tag + ": " + message + " (" + exception + ")");
+            logger.error(tag, message, exception);
+        }
+
+        @Override
+        public void debug(String tag, String message) {
+            logs.add("DEBUG " + tag + ": " + message);
+            logger.debug(tag, message);
+        }
+
+        @Override
+        public void debug(String tag, String message, Throwable exception) {
+            logs.add("DEBUG " + tag + ": " + message + " (" + exception + ")");
+            logger.debug(tag, message, exception);
+        }
+
+        @Override
+        public ApplicationType getType() {
+            return type;
+        }
+
+        @Override
+        public int getVersion() {
+            return 1;
+        }
+
+        @Override
+        public long getJavaHeap() {
+            return 0;
+        }
+
+        @Override
+        public long getNativeHeap() {
+            return 0;
+        }
+
+        @Override
+        public Preferences getPreferences(String name) {
+            throw new UnsupportedOperationException("Preferences not available in test");
+        }
+
+        @Override
+        public Clipboard getClipboard() {
+            return null;
+        }
+
+        @Override
+        public void postRunnable(Runnable runnable) {
+            runnable.run();
+        }
+
+        @Override
+        public void exit() {
+            // no-op
+        }
+
+        @Override
+        public void addLifecycleListener(LifecycleListener listener) {
+            // no-op
+        }
+
+        @Override
+        public void removeLifecycleListener(LifecycleListener listener) {
+            // no-op
+        }
+
+        @Override
+        public void setLogLevel(int logLevel) {
+            this.logLevel = logLevel;
+        }
+
+        @Override
+        public int getLogLevel() {
+            return logLevel;
+        }
+
+        @Override
+        public ApplicationLogger getApplicationLogger() {
+            return logger;
+        }
+
+        @Override
+        public void setApplicationLogger(ApplicationLogger applicationLogger) {
+            // ignore custom logger so we always capture entries
+        }
+
+        private final class RecordingLogger implements ApplicationLogger {
+            @Override
+            public void log(String tag, String message) {
+                logs.add("LOGGER " + tag + ": " + message);
+            }
+
+            @Override
+            public void log(String tag, String message, Throwable exception) {
+                logs.add("LOGGER " + tag + ": " + message + " (" + exception + ")");
+            }
+
+            @Override
+            public void error(String tag, String message) {
+                logs.add("LOGGER ERROR " + tag + ": " + message);
+            }
+
+            @Override
+            public void error(String tag, String message, Throwable exception) {
+                logs.add("LOGGER ERROR " + tag + ": " + message + " (" + exception + ")");
+            }
+
+            @Override
+            public void debug(String tag, String message) {
+                logs.add("LOGGER DEBUG " + tag + ": " + message);
+            }
+
+            @Override
+            public void debug(String tag, String message, Throwable exception) {
+                logs.add("LOGGER DEBUG " + tag + ": " + message + " (" + exception + ")");
+            }
+        }
+    }
+}

--- a/docs/scene-transition-log-guide.md
+++ b/docs/scene-transition-log-guide.md
@@ -1,0 +1,68 @@
+# Scene Transition Log Guide
+
+This guide summarizes the steps used to run the LibGDX hamster game on both the desktop and Android targets in a headless CI container and capture the scene transition logs mentioned in recent investigations.
+
+## Desktop (LWJGL3) run with `xvfb`
+
+1. Install Xvfb once in the container:
+   ```bash
+   apt-get update
+   apt-get install -y xvfb
+   ```
+2. Launch the desktop target under a virtual display and stop it after a short window (the hamster auto-wins and resets on its own):
+   ```bash
+   timeout 40 xvfb-run -a ./gradlew :lwjgl3:run --console=plain --no-daemon | tee desktop.log
+   ```
+3. Review `desktop.log` for lines such as:
+   ```
+   [HamstersGame] Entering Scene 1 (Gameplay) (reason: initial startup) on Desktop
+   [HamstersGame] Transition Scene 1 (Gameplay) -> Scene 2 (Game Over) (reason: hamster victory via auto-win) on Desktop
+   ```
+
+## Android emulator run with `xvfb`
+
+1. Download and unpack the Android command-line tools:
+   ```bash
+   mkdir -p $HOME/android-sdk/cmdline-tools
+   wget https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -O cmdline-tools.zip
+   unzip -q cmdline-tools.zip -d cmdline-tools
+   mv cmdline-tools/cmdline-tools cmdline-tools/latest
+   rm cmdline-tools.zip
+   export ANDROID_HOME=$HOME/android-sdk
+   export ANDROID_SDK_ROOT=$ANDROID_HOME
+   export PATH=$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools:$ANDROID_HOME/cmdline-tools/latest/bin:$PATH
+   ```
+2. Install the required SDK components (platform tools, API 28 platform & system image, and the emulator binary):
+   ```bash
+   yes | sdkmanager "platform-tools" "platforms;android-28" "emulator" "system-images;android-28;default;x86_64"
+   ```
+3. Create an Android Virtual Device:
+   ```bash
+   yes | avdmanager create avd -n hamster_api28 -k "system-images;android-28;default;x86_64" --device "pixel"
+   ```
+4. Start the emulator inside a virtual display (software rendering is required in this environment):
+   ```bash
+   xvfb-run -a emulator -avd hamster_api28 -no-snapshot -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect -accel off > /tmp/emulator.log 2>&1 &
+   adb wait-for-device
+   ```
+5. Once the device is ready, install and launch the game:
+   ```bash
+   ./gradlew :android:installDebug --console=plain --no-daemon
+   adb logcat -c
+   adb shell am start -n tatar.eljah.hamsters/tatar.eljah.hamsters.android.AndroidLauncher
+   ```
+6. Capture the logs that confirm Scene 2 is presented after the auto-victory:
+   ```bash
+   adb logcat -d HamstersGame:I *:S > android.log
+   ```
+   The resulting `android.log` contains entries such as:
+   ```
+   HamstersGame: Entering Scene 1 (Gameplay) (reason: initial startup) on Android
+   HamstersGame: Transition Scene 1 (Gameplay) -> Scene 2 (Game Over) (reason: hamster victory via auto-win) on Android
+   ```
+7. Shut down the emulator when finished to free resources:
+   ```bash
+   adb -s emulator-5554 emu kill
+   ```
+
+These steps reproduce the behavior expected by the logging tests and provide an auditable record of the transitions on both supported platforms while running entirely in headless CI infrastructure.


### PR DESCRIPTION
## Summary
- add a scene transition logging runbook that captures the commands for running the desktop target under xvfb
- document how to provision an Android emulator headlessly, launch the game, and collect the HamstersGame log lines confirming the Scene 1 -> Scene 2 transition

## Testing
- ./gradlew test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68dfe83cbb00832a8a6c4da5deff8472