### PR TITLE
Add logging for scene directory discovery

### DIFF
--- a/assets/assets.txt
+++ b/assets/assets.txt
@@ -6,8 +6,6 @@ blocks/block2.json
 blocks/block2.svg
 blocks/hamster.json
 blocks/hamster.svg
-blocks/hamster4.json
-blocks/hamster4.svg
 com/badlogic/gdx/utils/lsans-15.fnt
 com/badlogic/gdx/utils/lsans-15.png
 controls.png
@@ -23,7 +21,8 @@ hamster_old.png
 hamster_old.svg
 libgdx.png
 liner.svg
-scenes/scene.json
+scenes/scene1.json
+scenes/scene2.json
 ui/font-list.fnt
 ui/font-subtitle.fnt
 ui/font-window.fnt

--- a/core/src/main/java/tatar/eljah/hamsters/Main.java
+++ b/core/src/main/java/tatar/eljah/hamsters/Main.java
@@ -121,10 +121,23 @@ public class Main extends ApplicationAdapter {
         levelFiles.clear();
         FileHandle scenesDir = Gdx.files.internal("scenes");
         if (scenesDir.exists() && scenesDir.isDirectory()) {
-            for (FileHandle file : scenesDir.list()) {
-                Matcher matcher = SCENE_FILE_PATTERN.matcher(file.name());
-                if (matcher.matches()) {
-                    levelFiles.add(file.name());
+            FileHandle[] sceneEntries = scenesDir.list();
+            if (sceneEntries == null) {
+                Gdx.app.log("Main", "scenesDir.list() returned null");
+            } else {
+                StringBuilder listing = new StringBuilder();
+                for (int i = 0; i < sceneEntries.length; i++) {
+                    if (i > 0) {
+                        listing.append(", ");
+                    }
+                    listing.append(sceneEntries[i].name());
+                }
+                Gdx.app.log("Main", "scenesDir.list(): [" + listing + "]");
+                for (FileHandle file : sceneEntries) {
+                    Matcher matcher = SCENE_FILE_PATTERN.matcher(file.name());
+                    if (matcher.matches()) {
+                        levelFiles.add(file.name());
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- log the scene directory listing before filtering level files so we can see what discoverLevels() finds at runtime

## Testing
- xvfb-run -a ./gradlew lwjgl3:run --console=plain --no-daemon -Pheadless=true *(manually interrupted after verifying log output)*

------
https://chatgpt.com/codex/tasks/task_e_68e03a55d320832a998c5c7c6bd9dc14